### PR TITLE
Update saveSnapshot.cpp

### DIFF
--- a/QGLViewer/saveSnapshot.cpp
+++ b/QGLViewer/saveSnapshot.cpp
@@ -520,7 +520,7 @@ void QGLViewer::saveSnapshot(bool automatic, bool overwrite)
 		QString fileName;
 		QString selectedFormat = FDFormatString[snapshotFormat()];
 		fileName = QFileDialog::getSaveFileName(this, "Choose a file name to save under", snapshotFileName(), formats, &selectedFormat,
-												overwrite?QFileDialog::DontConfirmOverwrite:QFlag(0));
+												overwrite?QFileDialog::DontConfirmOverwrite:QFlags<QFileDialog::Option>(0));
 		setSnapshotFormat(Qtformat[selectedFormat]);
 
 		if (checkFileName(fileName, this, snapshotFormat()))


### PR DESCRIPTION
resolve the issue "operands to ?: have different types 'QFileDialog::Option' and 'QFlag'" when compile with g++ 4.9  and Qt 5.3.1
