### PR TITLE
Fix compilation errors on ARMv7, when `qreal` is defined to `float`

### DIFF
--- a/QGLViewer/manipulatedCameraFrame.cpp
+++ b/QGLViewer/manipulatedCameraFrame.cpp
@@ -196,7 +196,8 @@ void ManipulatedCameraFrame::zoom(qreal delta, const Camera * const camera) {
 		if (direction.norm() > 0.02 * sceneRadius || delta > 0.0)
 			translate(delta * direction);
 	} else {
-		const qreal coef = qMax(fabs((camera->frame()->coordinatesOf(camera->pivotPoint())).z), 0.2 * sceneRadius);
+		const qreal coef = qMax(fabs((camera->frame()->coordinatesOf(camera->pivotPoint())).z),
+                                        qreal(0.2) * sceneRadius);
 		Vec trans(0.0, 0.0, -coef * delta);
 		translate(inverseTransformOf(trans));
 	}

--- a/QGLViewer/quaternion.cpp
+++ b/QGLViewer/quaternion.cpp
@@ -126,18 +126,6 @@ void Quaternion::setFromRotationMatrix(const qreal m[3][3])
 }
 
 #ifndef DOXYGEN
-void Quaternion::setFromRotationMatrix(const float m[3][3])
-{
-	qWarning("setFromRotationMatrix now expects a double[3][3] parameter");
-
-	qreal mat[3][3];
-	for (int i=0; i<3; ++i)
-		for (int j=0; j<3; ++j)
-			mat[i][j] = qreal(m[i][j]);
-
-	setFromRotationMatrix(mat);
-}
-
 void Quaternion::setFromRotatedBase(const Vec& X, const Vec& Y, const Vec& Z)
 {
 	qWarning("setFromRotatedBase is deprecated, use setFromRotatedBasis instead");

--- a/QGLViewer/quaternion.h
+++ b/QGLViewer/quaternion.h
@@ -104,7 +104,6 @@ public:
 	{ q[0]=q0;    q[1]=q1;    q[2]=q2;    q[3]=q3; }
 
 #ifndef DOXYGEN
-	void setFromRotationMatrix(const float m[3][3]);
 	void setFromRotatedBase(const Vec& X, const Vec& Y, const Vec& Z);
 #endif
 	void setFromRotationMatrix(const qreal m[3][3]);

--- a/QGLViewer/saveSnapshot.cpp
+++ b/QGLViewer/saveSnapshot.cpp
@@ -321,7 +321,7 @@ bool QGLViewer::saveImageSnapshot(const QString& fileName)
 	qreal zNear = camera()->zNear();
 	qreal zFar = camera()->zFar();
 
-	qreal xMin, yMin;
+	QGLdouble xMin, yMin;
 	bool expand = imageInterface->expandFrustum->isChecked();
 	if (camera()->type() == qglviewer::Camera::PERSPECTIVE)
 		if ((expand && (newAspectRatio>aspectRatio)) || (!expand && (newAspectRatio<aspectRatio)))

--- a/QGLViewer/vec.h
+++ b/QGLViewer/vec.h
@@ -134,8 +134,8 @@ public:
 	}
 
 #ifndef DOXYGEN
-	/*! This method is deprecated since version 2.0. Use operator const double* instead. */
-	const double* address() const { qWarning("Vec::address() is deprecated, use operator const double* instead."); return operator const double*(); }
+	/*! This method is deprecated since version 2.0. Use operator const qreal* instead. */
+	const qreal* address() const { qWarning("Vec::address() is deprecated, use operator const qreal* instead."); return operator const qreal*(); }
 #endif
 
 	/*! Conversion operator returning the memory address of the vector.
@@ -146,7 +146,7 @@ public:
   glNormal3dv(normal);
   glVertex3dv(pos);
   \endcode */
-	operator const double*() const {
+	operator const qreal*() const {
 #ifdef QGLVIEWER_UNION_NOT_SUPPORTED
 		return &x;
 #else
@@ -156,8 +156,8 @@ public:
 
 	/*! Non const conversion operator returning the memory address of the vector.
 
-  Useful to pass a Vec to a method that requires and fills a \c double*, as provided by certain libraries. */
-	operator double*() {
+  Useful to pass a Vec to a method that requires and fills a \c qreal*, as provided by certain libraries. */
+	operator qreal*() {
 #ifdef QGLVIEWER_UNION_NOT_SUPPORTED
 		return &x;
 #else


### PR DESCRIPTION
libQGLViewer-2.6.3 does not compile for Fedora 24, on ARMv7. The reason is that Qt5 is compile with `qreal` defined to `float`. This pull-request makes the modifications that are necessary to make the code compile.
