### PR TITLE
Fix a compilation error: missing <QMap>

### DIFF
--- a/QGLViewer/camera.h
+++ b/QGLViewer/camera.h
@@ -1,6 +1,7 @@
 #ifndef QGLVIEWER_CAMERA_H
 #define QGLVIEWER_CAMERA_H
 
+#include <QMap>
 #include "keyFrameInterpolator.h"
 class QGLViewer;
 


### PR DESCRIPTION
```
In file included from qglviewer.h:4:0,
                 from qglviewer.cpp:1:
camera.h:528:46: error: field ‘kfi_’ has incomplete type ‘QMap<unsigned int, qglviewer::KeyFrameInterpolator*>’
   QMap<unsigned int, KeyFrameInterpolator *> kfi_;
                                              ^~~~
```

Tested on Fedora 25, with Qt 5.7.1.

(Cc @maxGimeno)