### PR TITLE
Fix some semantic warning

### DIFF
--- a/QGLViewer/VRender/BSPSortMethod.cpp
+++ b/QGLViewer/VRender/BSPSortMethod.cpp
@@ -26,7 +26,7 @@ class BSPTree
 		void recursFillPrimitiveArray(vector<PtrPrimitive>&) const;
 	private:
 		BSPNode *_root;
-		vector<Segment *> _segments;	// these are for storing segments and points when _root is null
+        vector<Segment *> _segments;	// these are for storing segments and points when _root is null
 		vector<Point *> _points;
 };
 
@@ -44,7 +44,7 @@ void BSPSortMethod::sortPrimitives(std::vector<PtrPrimitive>& primitive_tab,VRen
 																// by the insertion and can not be dynamic_casted anymore.
 	for(unsigned int i=0;i<primitive_tab.size();++i,++nbinserted)
 	{
-		if((P = dynamic_cast<Polygone *>(primitive_tab[i])) != NULL)
+        if((P = dynamic_cast<Polygone *>(primitive_tab[i])) != nullptr)
 			tree.insert(P);
 		else
 			segments_and_points.push_back(primitive_tab[i]);
@@ -60,9 +60,9 @@ void BSPSortMethod::sortPrimitives(std::vector<PtrPrimitive>& primitive_tab,VRen
 
 	for(unsigned int j=0;j<segments_and_points.size();++j,++nbinserted)
 	{
-		if((S = dynamic_cast<Segment *>(segments_and_points[j])) != NULL)
+        if((S = dynamic_cast<Segment *>(segments_and_points[j])) != nullptr)
 			tree.insert(S);
-		else if((p = dynamic_cast<Point *>(segments_and_points[j])) != NULL)
+        else if((p = dynamic_cast<Point *>(segments_and_points[j])) != nullptr)
 			tree.insert(p);
 
 		if(nbinserted%N==0)
@@ -112,7 +112,7 @@ class BSPNode
 
 BSPTree::BSPTree()
 {
-	_root = NULL;
+    _root = nullptr;
 }
 
 BSPTree::~BSPTree()
@@ -120,13 +120,13 @@ BSPTree::~BSPTree()
 	delete _root;
 }
 
-void BSPTree::insert(Point *P) 	{ if(_root == NULL) _points.push_back(P) 	; else _root->insert(P); }
-void BSPTree::insert(Segment *S) { if(_root == NULL) _segments.push_back(S); else _root->insert(S); }
-void BSPTree::insert(Polygone *P){ if(_root == NULL) _root = new BSPNode(P); else _root->insert(P); }
+void BSPTree::insert(Point *P) 	{ if(_root == nullptr) _points.push_back(P) 	; else _root->insert(P); }
+void BSPTree::insert(Segment *S) { if(_root == nullptr) _segments.push_back(S); else _root->insert(S); }
+void BSPTree::insert(Polygone *P){ if(_root == nullptr) _root = new BSPNode(P); else _root->insert(P); }
 
 void BSPTree::recursFillPrimitiveArray(vector<PtrPrimitive>& tab) const
 {
-	if(_root != NULL) _root->recursFillPrimitiveArray(tab);
+    if(_root != nullptr) _root->recursFillPrimitiveArray(tab);
 
 	for(unsigned int i=0;i<_points.size();++i) tab.push_back(_points[i]);
 	for(unsigned int j=0;j<_segments.size();++j) tab.push_back(_segments[j]);
@@ -176,7 +176,7 @@ void BSPNode::Classify(Segment *S, Segment * & moins_, Segment * & plus_)
 		if(s1 == 0)
 		{
 			moins_ = S;
-			plus_  = NULL;
+            plus_  = nullptr;
 			return;
 		}
 		else
@@ -211,12 +211,12 @@ void BSPNode::Classify(Segment *S, Segment * & moins_, Segment * & plus_)
 		if(s1 == -1)
 		{
 			moins_ = S;
-			plus_ = NULL;
+            plus_ = nullptr;
 			return;
 		}
 		else
 		{
-			moins_ = NULL;
+            moins_ = nullptr;
 			plus_  = S;
 			return;
 		}
@@ -225,14 +225,14 @@ void BSPNode::Classify(Segment *S, Segment * & moins_, Segment * & plus_)
 	{
 		if(s2 > 0)
 		{
-			moins_ = NULL;
+            moins_ = nullptr;
 			plus_  = S;
 			return;
 		}
 		else
 		{
 			moins_ = S;
-			plus_  = NULL;
+            plus_  = nullptr;
 			return;
 		}
 	}
@@ -240,14 +240,14 @@ void BSPNode::Classify(Segment *S, Segment * & moins_, Segment * & plus_)
 	{
 		if(s1 > 0)
 		{
-			moins_ = NULL;
+            moins_ = nullptr;
 			plus_  = S;
 			return;
 		}
 		else
 		{
 			moins_ = S;
-			plus_  = NULL;
+            plus_  = nullptr;
 			return;
 		}
 	}
@@ -260,12 +260,12 @@ void BSPNode::Classify(Polygone *P, Polygone * & moins_, Polygone * & plus_)
 	static int Signs[100];
 	static double Zvals[100];
 
-	moins_ = NULL;
-	plus_ = NULL;
+    moins_ = nullptr;
+    plus_ = nullptr;
 
-	if(P == NULL)
+    if(P == nullptr)
 	{
-		//printf("BSPNode::Classify: Error. Null polygon.\n");
+        //printf("BSPNode::Classify: Error. Null polygon.\n");
 		return;
 	}
 
@@ -298,7 +298,7 @@ void BSPNode::Classify(Polygone *P, Polygone * & moins_, Polygone * & plus_)
 	if((Smin == 0)&&(Smax == 0))
 	{
 		moins_ = P;
-		plus_  = NULL;
+        plus_  = nullptr;
 		return;
 	}
 
@@ -307,7 +307,7 @@ void BSPNode::Classify(Polygone *P, Polygone * & moins_, Polygone * & plus_)
 	if(Smin == 1)
 	{
 		plus_  = P;
-		moins_ = NULL;
+        moins_ = nullptr;
 		return;
 	}
 
@@ -315,14 +315,14 @@ void BSPNode::Classify(Polygone *P, Polygone * & moins_, Polygone * & plus_)
 
 	if(Smax == -1)
 	{
-		plus_ = NULL;
+        plus_ = nullptr;
 		moins_ = P;
 		return;
 	}
 
 	if((Smin == -1)&&(Smax == 0))
 	{
-		plus_ = NULL;
+        plus_ = nullptr;
 		moins_ = P;
 		return;
 	}
@@ -330,7 +330,7 @@ void BSPNode::Classify(Polygone *P, Polygone * & moins_, Polygone * & plus_)
 	if((Smin == 0)&&(Smax == 1))
 	{
 		plus_ = P;
-		moins_ = NULL;
+        moins_ = nullptr;
 		return;
 	}
 
@@ -360,7 +360,7 @@ void BSPNode::Classify(Polygone *P, Polygone * & moins_, Polygone * & plus_)
 		// Ils y a des imprecisions numeriques dues au fait que le poly estpres du plan.
 
 		moins_ = P;
-		plus_  = NULL;
+        plus_  = nullptr;
 		return;
 	}
 
@@ -444,7 +444,7 @@ void BSPNode::Classify(Polygone *P, Polygone * & moins_, Polygone * & plus_)
 
 void BSPNode::insert(Polygone *P)
 {
-	Polygone *side_plus = NULL, *side_moins = NULL;
+    Polygone *side_plus = nullptr, *side_moins = nullptr;
 
 	// 1 - Check on which size the polygon is, possibly split.
 
@@ -452,15 +452,15 @@ void BSPNode::insert(Polygone *P)
 
 	// 2 - insert polygons
 
-	if(side_plus != NULL) {
-		if(fils_plus == NULL)
+    if(side_plus != nullptr) {
+        if(fils_plus == nullptr)
 			fils_plus = new BSPNode(side_plus);
 		else
 			fils_plus->insert(side_plus);
 	}
 	
-	if(side_moins != NULL) {
-		if(fils_moins == NULL)
+    if(side_moins != nullptr) {
+        if(fils_moins == nullptr)
 			fils_moins = new BSPNode(side_moins);
 		else
 			fils_moins->insert(side_moins);
@@ -469,7 +469,7 @@ void BSPNode::insert(Polygone *P)
 
 void BSPNode::recursFillPrimitiveArray(vector<PtrPrimitive>& primitive_tab) const
 {
-  if(fils_plus != NULL)
+  if(fils_plus != nullptr)
     fils_plus->recursFillPrimitiveArray(primitive_tab);
 
   for(unsigned int i=0;i<seg_plus.size();++i)
@@ -477,10 +477,10 @@ void BSPNode::recursFillPrimitiveArray(vector<PtrPrimitive>& primitive_tab) cons
   for(unsigned int j=0;j<pts_plus.size();++j)
     primitive_tab.push_back(pts_plus[j]);
 
-  if(polygone != NULL)
+  if(polygone != nullptr)
     primitive_tab.push_back(polygone);
 
-  if(fils_moins != NULL)
+  if(fils_moins != nullptr)
     fils_moins->recursFillPrimitiveArray(primitive_tab);
 
   for(unsigned int i2=0;i2<seg_moins.size();++i2)
@@ -494,14 +494,14 @@ void BSPNode::insert(Point *P)
 	int res = Classify(P);
 
 	if(res == -1) {
-		if(fils_moins == NULL)
+        if(fils_moins == nullptr)
 			pts_moins.push_back(P);
 		else
 			fils_moins->insert(P);
 	}
 
 	if(res == 1) {
-		if(fils_plus == NULL)
+        if(fils_plus == nullptr)
 			pts_plus.push_back(P);
 		else
 			fils_plus->insert(P);
@@ -510,19 +510,19 @@ void BSPNode::insert(Point *P)
 
 void BSPNode::insert(Segment *S)
 {
-	Segment *side_plus = NULL, *side_moins = NULL;
+    Segment *side_plus = nullptr, *side_moins = nullptr;
 
 	Classify(S,side_moins,side_plus);
 
-	if(side_plus != NULL) {
-		if(fils_plus == NULL)
+    if(side_plus != nullptr) {
+        if(fils_plus == nullptr)
 			seg_plus.push_back(side_plus);
 		else
 			fils_plus->insert(side_plus);
 	}
 
-	if(side_moins != NULL) {
-		if(fils_moins == NULL)
+    if(side_moins != nullptr) {
+        if(fils_moins == nullptr)
 			seg_moins.push_back(side_moins);
 		else
 			fils_moins->insert(side_moins);
@@ -535,8 +535,8 @@ BSPNode::BSPNode(Polygone *P)
 
   initEquation(P,a,b,c,d);
 
-  fils_moins = NULL;
-  fils_plus  = NULL;
+  fils_moins = nullptr;
+  fils_plus  = nullptr;
 }
 
 void BSPNode::initEquation(const Polygone *P,double & a, double & b, double & c, double & d)

--- a/QGLViewer/VRender/BackFaceCullingOptimizer.cpp
+++ b/QGLViewer/VRender/BackFaceCullingOptimizer.cpp
@@ -15,13 +15,13 @@ void BackFaceCullingOptimizer::optimize(std::vector<PtrPrimitive>& primitives_ta
 	int nb_culled = 0 ;
 
 	for(size_t i=0;i<primitives_tab.size();++i)
-		if((P = dynamic_cast<Polygone *>(primitives_tab[i])) != NULL)
+		if((P = dynamic_cast<Polygone *>(primitives_tab[i])) != nullptr)
 		{
 						for(unsigned int j=0;j<P->nbVertices();++j)
 				if(( (P->vertex(j+2) - P->vertex(j+1))^(P->vertex(j+1) - P->vertex(j))).z() > 0.0 )
 				{
 					delete primitives_tab[i] ;
-					primitives_tab[i] = NULL ;
+					primitives_tab[i] = nullptr ;
 					++nb_culled ;
 					break ;
 				}
@@ -31,7 +31,7 @@ void BackFaceCullingOptimizer::optimize(std::vector<PtrPrimitive>& primitives_ta
 
 	int j=0 ;
 	for(size_t k=0;k<primitives_tab.size();++k)
-		if(primitives_tab[k] != NULL)
+		if(primitives_tab[k] != nullptr)
 			primitives_tab[j++] = primitives_tab[k] ;
 
 	primitives_tab.resize(j) ;

--- a/QGLViewer/VRender/EPSExporter.cpp
+++ b/QGLViewer/VRender/EPSExporter.cpp
@@ -46,7 +46,7 @@ void EPSExporter::writeHeader(QTextStream& out) const
 
 	out << "/threshold " << EPS_GOURAUD_THRESHOLD << " def\n";
 
-	for(int i = 0; GOURAUD_TRIANGLE_EPS[i] != NULL; i++)
+	for(int i = 0; GOURAUD_TRIANGLE_EPS[i] != nullptr; i++)
 		out << GOURAUD_TRIANGLE_EPS[i] << "\n";
 #ifdef A_VOIR
 	out <<  "\n" <<  << " setlinewidth\n\n", _lineWidth;
@@ -102,7 +102,7 @@ const char *EPSExporter::GOURAUD_TRIANGLE_EPS[] =
 	"div 10 1 roll 7 index 5 index 3 index add add 3 div 10 1 roll 6 index 4 ",
 	"index 2 index add add 3 div 10 1 roll 9 {pop} repeat 3 array astore ",
 	"triangle } ifelse } bd",
-	NULL
+	nullptr
 };
 
 void EPSExporter::spewPolygone(const Polygone *P, QTextStream& out)

--- a/QGLViewer/VRender/Exporter.cpp
+++ b/QGLViewer/VRender/Exporter.cpp
@@ -21,7 +21,7 @@ void Exporter::exportToFile(const QString& filename,
 	QFile file(filename);
 
 	if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
-		QMessageBox::warning(NULL, QGLViewer::tr("Exporter error", "Message box window title"), QGLViewer::tr("Unable to open file %1.").arg(filename));
+		QMessageBox::warning(nullptr, QGLViewer::tr("Exporter error", "Message box window title"), QGLViewer::tr("Unable to open file %1.").arg(filename));
 		return;
 	}
 
@@ -37,9 +37,9 @@ void Exporter::exportToFile(const QString& filename,
 		Segment *s = dynamic_cast<Segment *>(primitive_tab[i]) ;
 		Polygone *P = dynamic_cast<Polygone *>(primitive_tab[i]) ;
 
-		if(p != NULL) spewPoint(p,out) ;
-		if(s != NULL) spewSegment(s,out) ;
-		if(P != NULL) spewPolygone(P,out) ;
+		if(p != nullptr) spewPoint(p,out) ;
+		if(s != nullptr) spewSegment(s,out) ;
+		if(P != nullptr) spewPolygone(P,out) ;
 
 		if(i%N == 0)
 			vparams.progress(i/(float)primitive_tab.size(),QGLViewer::tr("Exporting to file %1").arg(filename)) ;

--- a/QGLViewer/VRender/ParserGL.cpp
+++ b/QGLViewer/VRender/ParserGL.cpp
@@ -93,7 +93,7 @@ void ParserGL::parseFeedbackBuffer(	GLfloat *buffer,int size,
 
 					primitive_tab.push_back(ParserUtils::checkSegment(S)) ;
 
-					if(S == NULL)
+					if(S == nullptr)
 						nb_degenerated_lines++ ;
 
 					nb_lines++ ;
@@ -115,7 +115,7 @@ void ParserGL::parseFeedbackBuffer(	GLfloat *buffer,int size,
 
 					primitive_tab.push_back(ParserUtils::checkPolygon(P)) ;
 
-					if(P == NULL)
+					if(P == nullptr)
 						nb_degenerated_polys++ ;
 
 					nb_polys++ ;
@@ -128,7 +128,7 @@ void ParserGL::parseFeedbackBuffer(	GLfloat *buffer,int size,
 
 					primitive_tab.push_back(Pt);//ParserUtils::checkPoint(Pt)) ;
 
-					if(Pt == NULL)
+					if(Pt == nullptr)
 						nb_degenerated_points++ ;
 
 					nb_points++ ;
@@ -156,7 +156,7 @@ PtrPrimitive ParserUtils::checkSegment(Segment *& P)
 	{
 		Point *pp = new Point(P->sommet3DColor(0)) ;
 		delete P ;
-		P = NULL ;
+		P = nullptr ;
 
 		return checkPoint(pp) ;
 	}
@@ -170,7 +170,7 @@ PtrPrimitive ParserUtils::checkPolygon(Polygone *& P)
 	{
 		cout << "unexpected case: Polygon with " << P->nbVertices() << " vertices !" << endl ;
 		delete P ;
-		return NULL ;
+		return nullptr ;
 	}
 
 	if(P->FlatFactor() < FLAT_POLYGON_EPS)
@@ -184,14 +184,14 @@ PtrPrimitive ParserUtils::checkPolygon(Polygone *& P)
 			{
 				Segment *pp = new Segment(P->sommet3DColor((i+1)%n),P->sommet3DColor((i+2)%n)) ;
 				delete P ;
-				P = NULL ;
+				P = nullptr ;
 
 				return checkSegment(pp) ;
 			}
 
 		Point *pp = new Point(P->sommet3DColor(0)) ;
 		delete P ;
-		P = NULL ;
+		P = nullptr ;
 
 		return checkPoint(pp) ;
 	}

--- a/QGLViewer/VRender/PrimitivePositioning.cpp
+++ b/QGLViewer/VRender/PrimitivePositioning.cpp
@@ -355,8 +355,8 @@ gpc_polygon PrimitivePositioning::createGPCPolygon_XY(const Polygone *P)
 	gpc_polygon p ;
 
 	p.num_contours = 0 ;
-	p.hole = NULL ;
-	p.contour = NULL ;
+	p.hole = nullptr ;
+	p.contour = nullptr ;
 
 	gpc_vertex_list *gpc_p_verts = new gpc_vertex_list ;
 
@@ -377,7 +377,7 @@ gpc_polygon PrimitivePositioning::createGPCPolygon_XY(const Polygone *P)
 void PrimitivePositioning::getsigns(const Primitive *P,const NVector3& v,double C,
 												vector<int>& signs,vector<double>& zvals,int& Smin,int& Smax,double I_EPS)
 {
-	if(P == NULL)
+	if(P == nullptr)
 		throw runtime_error("Null primitive in getsigns !") ;
 
 	size_t n = P->nbVertices() ;
@@ -422,8 +422,8 @@ void PrimitivePositioning::split(Polygone *P,const NVector3& v,double C,Primitiv
 	vector<int> Signs ;
 	vector<double> Zvals ;
 
-	P_plus = NULL ;
-	P_moins = NULL ;
+	P_plus = nullptr ;
+	P_moins = nullptr ;
 
 	int Smin = 1 ;
 	int Smax = -1 ;
@@ -432,12 +432,12 @@ void PrimitivePositioning::split(Polygone *P,const NVector3& v,double C,Primitiv
 
 	size_t n = P->nbVertices() ;
 
-	if((Smin == 0)&&(Smax == 0)){ P_moins = P ; P_plus = NULL ; return ; }	// Polygone inclus dans le plan
-	if(Smin == 1) 					{ P_plus = P ; P_moins = NULL ; return ; }	// Polygone tout positif
-	if(Smax == -1) 					{ P_plus = NULL ; P_moins = P ; return ; }	// Polygone tout negatif
+	if((Smin == 0)&&(Smax == 0)){ P_moins = P ; P_plus = nullptr ; return ; }	// Polygone inclus dans le plan
+	if(Smin == 1) 					{ P_plus = P ; P_moins = nullptr ; return ; }	// Polygone tout positif
+	if(Smax == -1) 					{ P_plus = nullptr ; P_moins = P ; return ; }	// Polygone tout negatif
 
-	if((Smin == -1)&&(Smax == 0)) { P_plus = NULL ; P_moins = P ; return ; }	// Polygone tout negatif ou null
-	if((Smin == 0)&&(Smax == 1))  { P_plus = P ; P_moins = NULL ; return ; }	// Polygone tout positif ou null
+	if((Smin == -1)&&(Smax == 0)) { P_plus = nullptr ; P_moins = P ; return ; }	// Polygone tout negatif ou null
+	if((Smin == 0)&&(Smax == 1))  { P_plus = P ; P_moins = nullptr ; return ; }	// Polygone tout positif ou null
 
 	// Reste le cas Smin = -1 et Smax = 1. Il faut couper
 
@@ -461,7 +461,7 @@ void PrimitivePositioning::split(Polygone *P,const NVector3& v,double C,Primitiv
 	}
 
 	// Ils y a des imprecisions numeriques dues au fait que le poly estpres du plan.
-	if((nZero > 2)||(nconsZero > 0)) { P_moins = P ; P_plus  = NULL ; return ; }
+	if((nZero > 2)||(nconsZero > 0)) { P_moins = P ; P_plus  = nullptr ; return ; }
 
 	int dep=0 ; while(Signs[dep] == 0) dep++ ;
 	int prev_sign = Signs[dep] ;
@@ -539,12 +539,12 @@ void PrimitivePositioning::split(Point *P,const NVector3& v,double C,Primitive *
 	if(v*P->vertex(0)-C > -_EPS)
 	{
 		P_plus = P ;
-		P_moins = NULL ;
+		P_moins = nullptr ;
 	}
 	else
 	{
 		P_moins = P ;
-		P_plus = NULL ;
+		P_plus = nullptr ;
 	}
 }
 
@@ -553,8 +553,8 @@ void PrimitivePositioning::split(Segment *S,const NVector3& v,double C,Primitive
 	vector<int> Signs ;
 	vector<double> Zvals ;
 
-	P_plus = NULL ;
-	P_moins = NULL ;
+	P_plus = nullptr ;
+	P_moins = nullptr ;
 
 	int Smin = 1 ;
 	int Smax = -1 ;
@@ -563,12 +563,12 @@ void PrimitivePositioning::split(Segment *S,const NVector3& v,double C,Primitive
 
 	size_t n = S->nbVertices() ;
 
-	if((Smin == 0)&&(Smax == 0)) 	{ P_moins = S ; P_plus = NULL ; return ; }	// Polygone inclus dans le plan
-	if(Smin == 1) 						{ P_plus = S ; P_moins = NULL ; return ; }	// Polygone tout positif
-	if(Smax == -1) 					{ P_plus = NULL ; P_moins = S ; return ; }	// Polygone tout negatif
+	if((Smin == 0)&&(Smax == 0)) 	{ P_moins = S ; P_plus = nullptr ; return ; }	// Polygone inclus dans le plan
+	if(Smin == 1) 						{ P_plus = S ; P_moins = nullptr ; return ; }	// Polygone tout positif
+	if(Smax == -1) 					{ P_plus = nullptr ; P_moins = S ; return ; }	// Polygone tout negatif
 
-	if((Smin == -1)&&(Smax == 0)) { P_plus = NULL ; P_moins = S ; return ; }	// Polygone tout negatif ou null
-	if((Smin == 0)&&(Smax == 1))  { P_plus = S ; P_moins = NULL ; return ; }	// Polygone tout positif ou null
+	if((Smin == -1)&&(Smax == 0)) { P_plus = nullptr ; P_moins = S ; return ; }	// Polygone tout negatif ou null
+	if((Smin == 0)&&(Smax == 1))  { P_plus = S ; P_moins = nullptr ; return ; }	// Polygone tout positif ou null
 
 	// Reste le cas Smin = -1 et Smax = 1. Il faut couper
 	// On teste la coherence des signes.
@@ -588,7 +588,7 @@ void PrimitivePositioning::split(Segment *S,const NVector3& v,double C,Primitive
 	}
 
 	// Ils y a des imprecisions numeriques dues au fait que le poly estpres du plan.
-	if((nZero > 2)||(nconsZero > 0)) { P_moins = S ; P_plus  = NULL ; return ; }
+	if((nZero > 2)||(nconsZero > 0)) { P_moins = S ; P_plus  = nullptr ; return ; }
 
 	double Z1 = Zvals[0] ;
 	double Z2 = Zvals[1] ;
@@ -620,8 +620,8 @@ void PrimitivePositioning::split(Segment *S,const NVector3& v,double C,Primitive
 
 void PrimitivePositioning::splitPrimitive(Primitive *P,const NVector3& v,double c, Primitive *& prim_up,Primitive *& prim_lo)
 {
-	Polygone *p1 = dynamic_cast<Polygone *>(P) ; if(p1 != NULL) PrimitivePositioning::split(p1,v,c,prim_up,prim_lo) ;
-	Segment  *p2 = dynamic_cast<Segment  *>(P) ; if(p2 != NULL) PrimitivePositioning::split(p2,v,c,prim_up,prim_lo) ;
-	Point    *p3 = dynamic_cast<Point    *>(P) ; if(p3 != NULL) PrimitivePositioning::split(p3,v,c,prim_up,prim_lo) ;
+	Polygone *p1 = dynamic_cast<Polygone *>(P) ; if(p1 != nullptr) PrimitivePositioning::split(p1,v,c,prim_up,prim_lo) ;
+	Segment  *p2 = dynamic_cast<Segment  *>(P) ; if(p2 != nullptr) PrimitivePositioning::split(p2,v,c,prim_up,prim_lo) ;
+	Point    *p3 = dynamic_cast<Point    *>(P) ; if(p3 != nullptr) PrimitivePositioning::split(p3,v,c,prim_up,prim_lo) ;
 }
 

--- a/QGLViewer/VRender/TopologicalSortMethod.cpp
+++ b/QGLViewer/VRender/TopologicalSortMethod.cpp
@@ -455,12 +455,12 @@ void TopologicalSortUtils::recursTopologicalSort(	vector< vector<size_t> >& prec
 					bool prim_lower_prec_contains_ip1 = false ;
 					bool prim_upper_prec_contains_ip1 = false ;
 
-					Primitive *prim_upper = NULL ;
-					Primitive *prim_lower = NULL ;
+					Primitive *prim_upper = nullptr ;
+					Primitive *prim_lower = nullptr ;
 
 					PrimitivePositioning::splitPrimitive(primitive_tab[ancestors[i3]],normal,c,prim_upper,prim_lower) ;
 
-					if(prim_upper == NULL || prim_lower == NULL)
+					if(prim_upper == nullptr || prim_lower == nullptr)
 						continue ;
 #ifdef DEBUG_TS
 					cout << "Splitted primitive " << ancestors[i3] << endl ;

--- a/QGLViewer/VRender/VRender.cpp
+++ b/QGLViewer/VRender/VRender.cpp
@@ -24,9 +24,9 @@ using namespace std ;
 
 void vrender::VectorialRender(RenderCB render_callback, void *callback_params, VRenderParams& vparams)
 {
-	GLfloat *feedbackBuffer = NULL ;
-	SortMethod *sort_method = NULL ;
-	Exporter *exporter = NULL ;
+	GLfloat *feedbackBuffer = nullptr ;
+	SortMethod *sort_method = nullptr ;
+	Exporter *exporter = nullptr ;
 
 	try
 	{
@@ -40,12 +40,12 @@ void vrender::VectorialRender(RenderCB render_callback, void *callback_params, V
 
 		while(returned < 0)
 		{
-			if(feedbackBuffer != NULL)
+			if(feedbackBuffer != nullptr)
 				delete[] feedbackBuffer ;
 
 			feedbackBuffer = new GLfloat[vparams.size()] ;
 
-			if(feedbackBuffer == NULL)
+			if(feedbackBuffer == nullptr)
 				throw std::runtime_error("Out of memory during feedback buffer allocation.") ;
 
 			glFeedbackBuffer(vparams.size(), GL_3D_COLOR, feedbackBuffer);
@@ -83,10 +83,10 @@ void vrender::VectorialRender(RenderCB render_callback, void *callback_params, V
 		ParserGL parserGL ;
 		parserGL.parseFeedbackBuffer(feedbackBuffer,returned,primitive_tab,vparams) ;
 
-		if(feedbackBuffer != NULL)
+		if(feedbackBuffer != nullptr)
 		{
 			delete[] feedbackBuffer ;
-			feedbackBuffer = NULL ;
+			feedbackBuffer = nullptr ;
 		}
 
 		if(vparams.isEnabled(VRenderParams::OptimizeBackFaceCulling))
@@ -180,16 +180,16 @@ void vrender::VectorialRender(RenderCB render_callback, void *callback_params, V
 		for(unsigned int i=0;i<primitive_tab.size();++i)
 			delete primitive_tab[i] ;
 
-		if(exporter != NULL) delete exporter ;
-		if(sort_method != NULL) delete sort_method ;
+		if(exporter != nullptr) delete exporter ;
+		if(sort_method != nullptr) delete sort_method ;
 	}
 	catch(exception& e)
 	{
 		cout << "Render aborted: " << e.what() << endl ;
 
-		if(exporter != NULL) delete exporter ;
-		if(sort_method != NULL) delete sort_method ;
-		if(feedbackBuffer != NULL) delete[] feedbackBuffer ;
+		if(exporter != nullptr) delete exporter ;
+		if(sort_method != nullptr) delete sort_method ;
+		if(feedbackBuffer != nullptr) delete[] feedbackBuffer ;
 
 		throw e ;
 	}
@@ -200,7 +200,7 @@ VRenderParams::VRenderParams()
 	_options = 0 ;
 	_format = EPS ;
 	_filename = "" ;
-	_progress_function = NULL ;
+	_progress_function = nullptr ;
 	_sortMethod = BSPSort ;
 }
 

--- a/QGLViewer/VRender/VisibilityOptimizer.cpp
+++ b/QGLViewer/VRender/VisibilityOptimizer.cpp
@@ -53,12 +53,12 @@ void VisibilityOptimizer::optimize(vector<PtrPrimitive>& primitives,VRenderParam
 
         gpc_polygon cumulated_union ;
         cumulated_union.num_contours = 0 ;
-        cumulated_union.hole = NULL ;
-        cumulated_union.contour = NULL ;
+        cumulated_union.hole = nullptr ;
+        cumulated_union.contour = nullptr ;
         size_t nboptimised = 0 ;
 
         for(size_t pindex = primitives.size() - 1; long(pindex) >= 0;--pindex,++nboptimised)
-                if(primitives[pindex] != NULL)
+                if(primitives[pindex] != nullptr)
                 {
 #ifdef A_FAIRE
                         percentage_finished = pindex / (float)primitives.size() ;
@@ -87,11 +87,11 @@ void VisibilityOptimizer::optimize(vector<PtrPrimitive>& primitives,VRenderParam
                                         gpc_polygon new_poly ;
                                         gpc_polygon new_poly_reduced ;
                                         new_poly.num_contours = 0 ;
-                                        new_poly.hole = NULL ;
-                                        new_poly.contour = NULL ;
+                                        new_poly.hole = nullptr ;
+                                        new_poly.contour = nullptr ;
                                         new_poly_reduced.num_contours = 0 ;
-                                        new_poly_reduced.hole = NULL ;
-                                        new_poly_reduced.contour = NULL ;
+                                        new_poly_reduced.hole = nullptr ;
+                                        new_poly_reduced.contour = nullptr ;
 
                                         // 1 - creates a gpc_polygon corresponding to the current primitive
 
@@ -171,7 +171,7 @@ void VisibilityOptimizer::optimize(vector<PtrPrimitive>& primitives,VRenderParam
                                         {
                                                 ++nb_culled ;
                                                 delete p ;
-                                                primitives[pindex] = NULL ;
+                                                primitives[pindex] = nullptr ;
                                                 continue ;
                                         }
 
@@ -182,8 +182,8 @@ void VisibilityOptimizer::optimize(vector<PtrPrimitive>& primitives,VRenderParam
                                         {
                                                 gpc_polygon cumulated_union_tmp ;
                                                 cumulated_union_tmp.num_contours = 0 ;
-                                                cumulated_union_tmp.hole = NULL ;
-                                                cumulated_union_tmp.contour = NULL ;
+                                                cumulated_union_tmp.hole = nullptr ;
+                                                cumulated_union_tmp.contour = nullptr ;
 
                                                 gpc_polygon_clip(GPC_UNION,&new_poly,&cumulated_union,&cumulated_union_tmp) ;
 

--- a/QGLViewer/VRender/gpc.cpp
+++ b/QGLViewer/VRender/gpc.cpp
@@ -106,9 +106,9 @@ using namespace std ;
 #define MALLOC(p, b, s, t) {if ((b) > 0) { \
 							p= (t*)malloc(b); if (!(p)) { \
 							fprintf(stderr, "gpc malloc failure: %s\n", s); \
-							exit(0);}} else p= NULL;}
+							exit(0);}} else p= nullptr;}
 
-#define FREE(p)            {if (p) {free(p); (p)= NULL;}}
+#define FREE(p)            {if (p) {free(p); (p)= nullptr;}}
 
 
 /*
@@ -343,8 +343,8 @@ static edge_node **bound_list(lmt_node **lmt, double y)
 	/* Add node onto the tail end of the LMT */
 	MALLOC(*lmt, sizeof(lmt_node), "LMT insertion", lmt_node);
 	(*lmt)->y= y;
-	(*lmt)->first_bound= NULL;
-	(*lmt)->next= NULL;
+	(*lmt)->first_bound= nullptr;
+	(*lmt)->next= nullptr;
 	return &((*lmt)->first_bound);
   }
   else
@@ -354,7 +354,7 @@ static edge_node **bound_list(lmt_node **lmt, double y)
 	  existing_node= *lmt;
 	  MALLOC(*lmt, sizeof(lmt_node), "LMT insertion", lmt_node);
 	  (*lmt)->y= y;
-	  (*lmt)->first_bound= NULL;
+	  (*lmt)->first_bound= nullptr;
 	  (*lmt)->next= existing_node;
 	  return &((*lmt)->first_bound);
 	}
@@ -375,8 +375,8 @@ static void add_to_sbtree(int *entries, sb_tree **sbtree, double y)
 	/* Add a new tree node here */
 	MALLOC(*sbtree, sizeof(sb_tree), "scanbeam tree insertion", sb_tree);
 	(*sbtree)->y= y;
-	(*sbtree)->less= NULL;
-	(*sbtree)->more= NULL;
+	(*sbtree)->less= nullptr;
+	(*sbtree)->more= nullptr;
 	(*entries)++;
   }
   else
@@ -511,14 +511,14 @@ static edge_node *build_lmt(lmt_node **lmt, sb_tree **sbtree,
 			e[i].dx= (edge_table[v].vertex.x - e[i].bot.x) /
 					   (e[i].top.y - e[i].bot.y);
 			e[i].type= type;
-			e[i].outp[ABOVE]= NULL;
-			e[i].outp[BELOW]= NULL;
-			e[i].next= NULL;
-			e[i].prev= NULL;
+			e[i].outp[ABOVE]= nullptr;
+			e[i].outp[BELOW]= nullptr;
+			e[i].next= nullptr;
+			e[i].prev= nullptr;
 			e[i].succ= ((num_edges > 1) && (i < (num_edges - 1))) ?
-					   &(e[i + 1]) : NULL;
-			e[i].pred= ((num_edges > 1) && (i > 0)) ? &(e[i - 1]) : NULL;
-			e[i].next_bound= NULL;
+					   &(e[i + 1]) : nullptr;
+			e[i].pred= ((num_edges > 1) && (i > 0)) ? &(e[i - 1]) : nullptr;
+			e[i].next_bound= nullptr;
 			e[i].bside[CLIP]= (op == GPC_DIFF) ? RIGHT : LEFT;
 			e[i].bside[SUBJ]= LEFT;
 		  }
@@ -561,14 +561,14 @@ static edge_node *build_lmt(lmt_node **lmt, sb_tree **sbtree,
 			e[i].dx= (edge_table[v].vertex.x - e[i].bot.x) /
 					   (e[i].top.y - e[i].bot.y);
 			e[i].type= type;
-			e[i].outp[ABOVE]= NULL;
-			e[i].outp[BELOW]= NULL;
-			e[i].next= NULL;
-			e[i].prev= NULL;
+			e[i].outp[ABOVE]= nullptr;
+			e[i].outp[BELOW]= nullptr;
+			e[i].next= nullptr;
+			e[i].prev= nullptr;
 			e[i].succ= ((num_edges > 1) && (i < (num_edges - 1))) ?
-					   &(e[i + 1]) : NULL;
-			e[i].pred= ((num_edges > 1) && (i > 0)) ? &(e[i - 1]) : NULL;
-			e[i].next_bound= NULL;
+					   &(e[i + 1]) : nullptr;
+			e[i].pred= ((num_edges > 1) && (i > 0)) ? &(e[i - 1]) : nullptr;
+			e[i].next_bound= nullptr;
 			e[i].bside[CLIP]= (op == GPC_DIFF) ? RIGHT : LEFT;
 			e[i].bside[SUBJ]= LEFT;
 		  }
@@ -588,7 +588,7 @@ static void add_edge_to_aet(edge_node **aet, edge_node *edge, edge_node *prev)
 	/* Append edge onto the tail end of the AET */
 	*aet= edge;
 	edge->prev= prev;
-	edge->next= NULL;
+	edge->next= nullptr;
   }
   else
   {
@@ -643,7 +643,7 @@ static void add_intersection(it_node **it, edge_node *edge0, edge_node *edge1,
 	(*it)->ie[1]= edge1;
 	(*it)->point.x= x;
 	(*it)->point.y= y;
-	(*it)->next= NULL;
+	(*it)->next= nullptr;
   }
   else
   {
@@ -679,7 +679,7 @@ static void add_st_edge(st_node **st, it_node **it, edge_node *edge,
 	(*st)->xb= edge->xb;
 	(*st)->xt= edge->xt;
 	(*st)->dx= edge->dx;
-	(*st)->prev= NULL;
+	(*st)->prev= nullptr;
   }
   else
   {
@@ -722,7 +722,7 @@ static void build_intersection_table(it_node **it, edge_node *aet, double dy)
 
   /* Build intersection table for the current scanbeam */
   reset_it(it);
-  st= NULL;
+  st= nullptr;
 
   /* Process each AET edge */
   for (edge= aet; edge; edge= edge->next)
@@ -779,7 +779,7 @@ static void add_left(polygon_node *p, double x, double y)
 {
   vertex_node *nv;
 
-  if(p == NULL) throw runtime_error("GPC: Something's wrong.") ;
+  if(p == nullptr) throw runtime_error("GPC: Something's wrong.") ;
 
   /* Create a new vertex node and set its fields */
   MALLOC(nv, sizeof(vertex_node), "vertex node creation", vertex_node);
@@ -798,8 +798,8 @@ static void merge_left(polygon_node *p, polygon_node *q, polygon_node *list)
 {
   polygon_node *target;
 
-  if(p == NULL) throw runtime_error("GPC: Something's wrong.") ;
-  if(q == NULL) throw runtime_error("GPC: Something's wrong.") ;
+  if(p == nullptr) throw runtime_error("GPC: Something's wrong.") ;
+  if(q == nullptr) throw runtime_error("GPC: Something's wrong.") ;
 
   /* Label contour as a hole */
   q->proxy->hole= TRUE;
@@ -828,13 +828,13 @@ static void add_right(polygon_node *p, double x, double y)
 {
   vertex_node *nv = 0;
 
-  if(p == NULL) throw runtime_error("GPC: Something's wrong.") ;
+  if(p == nullptr) throw runtime_error("GPC: Something's wrong.") ;
 
   /* Create a new vertex node and set its fields */
   MALLOC(nv, sizeof(vertex_node), "vertex node creation", vertex_node);
   nv->x= x;
   nv->y= y;
-  nv->next= NULL;
+  nv->next= nullptr;
 
   /* Add vertex nv to the right end of the polygon's vertex list */
   p->proxy->v[RIGHT]->next= nv;
@@ -848,8 +848,8 @@ static void merge_right(polygon_node *p, polygon_node *q, polygon_node *list)
 {
   polygon_node *target = 0;
 
-  if(p == NULL) throw runtime_error("GPC: Something's wrong.") ;
-  if(q == NULL) throw runtime_error("GPC: Something's wrong.") ;
+  if(p == nullptr) throw runtime_error("GPC: Something's wrong.") ;
+  if(q == nullptr) throw runtime_error("GPC: Something's wrong.") ;
 
 
   /* Label contour as external */
@@ -891,7 +891,7 @@ static void add_local_min(polygon_node **p, edge_node *edge,
 
   nv->x= x;
   nv->y= y;
-  nv->next= NULL;
+  nv->next= nullptr;
 
   /* Initialise proxy to point to p itself */
   (*p)->proxy= (*p);
@@ -925,7 +925,7 @@ static void add_vertex(vertex_node **t, double x, double y)
 	MALLOC(*t, sizeof(vertex_node), "tristrip vertex creation", vertex_node);
 	(*t)->x= x;
 	(*t)->y= y;
-	(*t)->next= NULL;
+	(*t)->next= nullptr;
   }
   else
 	/* Head further down the list */
@@ -941,9 +941,9 @@ static void new_tristrip(polygon_node **tn, edge_node *edge,
 	MALLOC(*tn, sizeof(polygon_node), "tristrip node creation", polygon_node);
 	 **tn = polygon_node() ;
 
-	(*tn)->next= NULL;
-	(*tn)->v[LEFT]= NULL;
-	(*tn)->v[RIGHT]= NULL;
+	(*tn)->next= nullptr;
+	(*tn)->v[LEFT]= nullptr;
+	(*tn)->v[RIGHT]= nullptr;
 	(*tn)->active= 1;
 	add_vertex(&((*tn)->v[LEFT]), x, y);
 	edge->outp[ABOVE]= *tn;
@@ -1145,27 +1145,27 @@ void gpc_add_contour(gpc_polygon *p, gpc_vertex_list *new_contour, int hole)
 void gpc_polygon_clip(gpc_op op, gpc_polygon *subj, gpc_polygon *clip,
 					  gpc_polygon *result)
 {
-  sb_tree       *sbtree= NULL;
-  it_node       *it= NULL, *intersect=0;
+  sb_tree       *sbtree= nullptr;
+  it_node       *it= nullptr, *intersect=0;
   edge_node     *edge=0, *prev_edge=0, *next_edge=0, *succ_edge=0, *e0=0, *e1=0;
-  edge_node     *aet= NULL, *c_heap= NULL, *s_heap= NULL;
-  lmt_node      *lmt= NULL, *local_min=0;
-  polygon_node  *out_poly= NULL, *p=0, *q=0, *poly=0, *npoly=0, *cf= NULL;
+  edge_node     *aet= nullptr, *c_heap= nullptr, *s_heap= nullptr;
+  lmt_node      *lmt= nullptr, *local_min=0;
+  polygon_node  *out_poly= nullptr, *p=0, *q=0, *poly=0, *npoly=0, *cf= nullptr;
   vertex_node   *vtx=0, *nv=0;
   h_state        horiz[2];
   int            in[2], exists[2], parity[2]= {LEFT, LEFT};
   int            c, v, contributing=0, search, scanbeam= 0, sbt_entries= 0;
   int            vclass=0, bl=0, br=0, tl=0, tr=0;
-  double        *sbt= NULL, xb, px, yb, yt=0.0, dy=0.0, ix, iy;
+  double        *sbt= nullptr, xb, px, yb, yt=0.0, dy=0.0, ix, iy;
 
-  /* Test for trivial NULL result cases */
+  /* Test for trivial nullptr result cases */
   if (((subj->num_contours == 0) && (clip->num_contours == 0))
    || ((subj->num_contours == 0) && ((op == GPC_INT) || (op == GPC_DIFF)))
    || ((clip->num_contours == 0) &&  (op == GPC_INT)))
   {
 	result->num_contours= 0;
-	result->hole= NULL;
-	result->contour= NULL;
+	result->hole= nullptr;
+	result->contour= nullptr;
 	return;
   }
 
@@ -1180,12 +1180,12 @@ void gpc_polygon_clip(gpc_op op, gpc_polygon *subj, gpc_polygon *clip,
   if (clip->num_contours > 0)
 	c_heap= build_lmt(&lmt, &sbtree, &sbt_entries, clip, CLIP, op);
 
-  /* Return a NULL result if no contours contribute */
-  if (lmt == NULL)
+  /* Return a nullptr result if no contours contribute */
+  if (lmt == nullptr)
   {
 	result->num_contours= 0;
-	result->hole= NULL;
-	result->contour= NULL;
+	result->hole= nullptr;
+	result->contour= nullptr;
 	reset_lmt(&lmt);
 	FREE(s_heap);
 	FREE(c_heap);
@@ -1230,7 +1230,7 @@ void gpc_polygon_clip(gpc_op op, gpc_polygon *subj, gpc_polygon *clip,
 	  {
 		/* Add edges starting at this local minimum to the AET */
 		for (edge= local_min->first_bound; edge; edge= edge->next_bound)
-		  add_edge_to_aet(&aet, edge, NULL);
+		  add_edge_to_aet(&aet, edge, nullptr);
 
 		local_min= local_min->next;
 	  }
@@ -1371,7 +1371,7 @@ void gpc_polygon_clip(gpc_op op, gpc_polygon *subj, gpc_polygon *clip,
 			  px= xb;
 			}
 			edge->outp[ABOVE]= cf;
-			cf= NULL;
+			cf= nullptr;
 			break;
 		  case ELI:
 			add_left(edge->outp[BELOW], xb, yb);
@@ -1385,7 +1385,7 @@ void gpc_polygon_clip(gpc_op op, gpc_polygon *subj, gpc_polygon *clip,
 			  px= xb;
 			}
 			merge_right(cf, edge->outp[BELOW], out_poly);
-			cf= NULL;
+			cf= nullptr;
 			break;
 		  case ILI:
 			if (xb != px)
@@ -1394,13 +1394,13 @@ void gpc_polygon_clip(gpc_op op, gpc_polygon *subj, gpc_polygon *clip,
 			  px= xb;
 			}
 			edge->outp[ABOVE]= cf;
-			cf= NULL;
+			cf= nullptr;
 			break;
 		  case IRI:
 			add_right(edge->outp[BELOW], xb, yb);
 			px= xb;
 			cf= edge->outp[BELOW];
-			edge->outp[BELOW]= NULL;
+			edge->outp[BELOW]= nullptr;
 			break;
 		  case IMX:
 			if (xb != px)
@@ -1409,8 +1409,8 @@ void gpc_polygon_clip(gpc_op op, gpc_polygon *subj, gpc_polygon *clip,
 			  px= xb;
 			}
 			merge_left(cf, edge->outp[BELOW], out_poly);
-			cf= NULL;
-			edge->outp[BELOW]= NULL;
+			cf= nullptr;
+			edge->outp[BELOW]= nullptr;
 			break;
 		  case IMM:
 			if (xb != px)
@@ -1419,7 +1419,7 @@ void gpc_polygon_clip(gpc_op op, gpc_polygon *subj, gpc_polygon *clip,
 			  px= xb;
 		}
 			merge_left(cf, edge->outp[BELOW], out_poly);
-			edge->outp[BELOW]= NULL;
+			edge->outp[BELOW]= nullptr;
 			add_local_min(&out_poly, edge, xb, yb);
 			cf= edge->outp[ABOVE];
 			break;
@@ -1430,7 +1430,7 @@ void gpc_polygon_clip(gpc_op op, gpc_polygon *subj, gpc_polygon *clip,
 			  px= xb;
 		}
 			merge_right(cf, edge->outp[BELOW], out_poly);
-			edge->outp[BELOW]= NULL;
+			edge->outp[BELOW]= nullptr;
 			add_local_min(&out_poly, edge, xb, yb);
 			cf= edge->outp[ABOVE];
 			break;
@@ -1568,7 +1568,7 @@ void gpc_polygon_clip(gpc_op op, gpc_polygon *subj, gpc_polygon *clip,
 			{
 			  add_right(p, ix, iy);
 			  e1->outp[ABOVE]= p;
-			  e0->outp[ABOVE]= NULL;
+			  e0->outp[ABOVE]= nullptr;
 			}
 			break;
 		  case ELI:
@@ -1576,7 +1576,7 @@ void gpc_polygon_clip(gpc_op op, gpc_polygon *subj, gpc_polygon *clip,
 			{
 			  add_left(q, ix, iy);
 			  e0->outp[ABOVE]= q;
-			  e1->outp[ABOVE]= NULL;
+			  e1->outp[ABOVE]= nullptr;
 			}
 			break;
 		  case EMX:
@@ -1584,8 +1584,8 @@ void gpc_polygon_clip(gpc_op op, gpc_polygon *subj, gpc_polygon *clip,
 			{
 			  add_left(p, ix, iy);
 			  merge_right(p, q, out_poly);
-			  e0->outp[ABOVE]= NULL;
-			  e1->outp[ABOVE]= NULL;
+			  e0->outp[ABOVE]= nullptr;
+			  e1->outp[ABOVE]= nullptr;
 			}
 			break;
 		  case IMN:
@@ -1597,7 +1597,7 @@ void gpc_polygon_clip(gpc_op op, gpc_polygon *subj, gpc_polygon *clip,
 			{
 			  add_left(p, ix, iy);
 			  e1->outp[ABOVE]= p;
-			  e0->outp[ABOVE]= NULL;
+			  e0->outp[ABOVE]= nullptr;
 			}
 			break;
 		  case IRI:
@@ -1605,7 +1605,7 @@ void gpc_polygon_clip(gpc_op op, gpc_polygon *subj, gpc_polygon *clip,
 			{
 			  add_right(q, ix, iy);
 			  e0->outp[ABOVE]= q;
-			  e1->outp[ABOVE]= NULL;
+			  e1->outp[ABOVE]= nullptr;
 			}
 			break;
 		  case IMX:
@@ -1613,8 +1613,8 @@ void gpc_polygon_clip(gpc_op op, gpc_polygon *subj, gpc_polygon *clip,
 			{
 			  add_right(p, ix, iy);
 			  merge_left(p, q, out_poly);
-			  e0->outp[ABOVE]= NULL;
-			  e1->outp[ABOVE]= NULL;
+			  e0->outp[ABOVE]= nullptr;
+			  e1->outp[ABOVE]= nullptr;
 			}
 			break;
 		  case IMM:
@@ -1683,8 +1683,8 @@ void gpc_polygon_clip(gpc_op op, gpc_polygon *subj, gpc_polygon *clip,
 		  e1->next= prev_edge->next;
 		  prev_edge->next= e0->next;
 		}
-		  if(e0->next == NULL) throw runtime_error("GPC internal error.") ;
-		  if(e1->next == NULL) throw runtime_error("GPC internal error.") ;
+		  if(e0->next == nullptr) throw runtime_error("GPC internal error.") ;
+		  if(e1->next == nullptr) throw runtime_error("GPC internal error.") ;
 		e0->next->prev= prev_edge;
 		e1->next->prev= e1;
 		e0->next= next_edge;
@@ -1722,14 +1722,14 @@ void gpc_polygon_clip(gpc_op op, gpc_polygon *subj, gpc_polygon *clip,
 		  edge->bundle[BELOW][SUBJ]= edge->bundle[ABOVE][SUBJ];
 		  edge->xb= edge->xt;
 		  }
-		edge->outp[ABOVE]= NULL;
+		edge->outp[ABOVE]= nullptr;
 	  }
 	}
   } /* === END OF SCANBEAM PROCESSING ================================== */
 
   /* Generate result polygon from out_poly */
-  result->contour= NULL;
-  result->hole= NULL;
+  result->contour= nullptr;
+  result->hole= nullptr;
   result->num_contours= count_contours(out_poly);
   if (result->num_contours > 0)
   {
@@ -1796,8 +1796,8 @@ void gpc_polygon_to_tristrip(gpc_polygon *s, gpc_tristrip *t)
   gpc_polygon c;
 
   c.num_contours= 0;
-  c.hole= NULL;
-  c.contour= NULL;
+  c.hole= nullptr;
+  c.contour= nullptr;
   gpc_tristrip_clip(GPC_DIFF, s, &c, t);
 }
 
@@ -1805,27 +1805,27 @@ void gpc_polygon_to_tristrip(gpc_polygon *s, gpc_tristrip *t)
 void gpc_tristrip_clip(gpc_op op, gpc_polygon *subj, gpc_polygon *clip,
 					   gpc_tristrip *result)
 {
-  sb_tree       *sbtree= NULL;
-  it_node       *it= NULL, *intersect;
+  sb_tree       *sbtree= nullptr;
+  it_node       *it= nullptr, *intersect;
   edge_node     *edge=0, *prev_edge=0, *next_edge=0, *succ_edge=0, *e0=0, *e1=0;
-  edge_node     *aet= NULL, *c_heap= NULL, *s_heap= NULL, *cf=0;
-  lmt_node      *lmt= NULL, *local_min;
-  polygon_node  *tlist= NULL, *tn, *tnn, *p, *q;
+  edge_node     *aet= nullptr, *c_heap= nullptr, *s_heap= nullptr, *cf=0;
+  lmt_node      *lmt= nullptr, *local_min;
+  polygon_node  *tlist= nullptr, *tn, *tnn, *p, *q;
   vertex_node   *lt, *ltn, *rt, *rtn;
   h_state        horiz[2];
   vertex_type    cft = NUL;
   int            in[2], exists[2], parity[2]= {LEFT, LEFT};
   int            s, v, contributing=0, search, scanbeam= 0, sbt_entries= 0;
   int            vclass=0, bl=0, br=0, tl=0, tr=0;
-  double        *sbt= NULL, xb, px, nx, yb, yt=0.0, dy=0.0, ix, iy;
+  double        *sbt= nullptr, xb, px, nx, yb, yt=0.0, dy=0.0, ix, iy;
 
-  /* Test for trivial NULL result cases */
+  /* Test for trivial nullptr result cases */
   if (((subj->num_contours == 0) && (clip->num_contours == 0))
    || ((subj->num_contours == 0) && ((op == GPC_INT) || (op == GPC_DIFF)))
    || ((clip->num_contours == 0) &&  (op == GPC_INT)))
   {
 	result->num_strips= 0;
-	result->strip= NULL;
+	result->strip= nullptr;
 	return;
   }
 
@@ -1840,11 +1840,11 @@ void gpc_tristrip_clip(gpc_op op, gpc_polygon *subj, gpc_polygon *clip,
   if (clip->num_contours > 0)
 	c_heap= build_lmt(&lmt, &sbtree, &sbt_entries, clip, CLIP, op);
 
-  /* Return a NULL result if no contours contribute */
-  if (lmt == NULL)
+  /* Return a nullptr result if no contours contribute */
+  if (lmt == nullptr)
   {
 	result->num_strips= 0;
-	result->strip= NULL;
+	result->strip= nullptr;
 	reset_lmt(&lmt);
 	FREE(s_heap);
 	FREE(c_heap);
@@ -1883,7 +1883,7 @@ void gpc_tristrip_clip(gpc_op op, gpc_polygon *subj, gpc_polygon *clip,
 	  {
 		/* Add edges starting at this local minimum to the AET */
 		for (edge= local_min->first_bound; edge; edge= edge->next_bound)
-		  add_edge_to_aet(&aet, edge, NULL);
+		  add_edge_to_aet(&aet, edge, nullptr);
 
 		local_min= local_min->next;
 	  }
@@ -2019,18 +2019,18 @@ void gpc_tristrip_clip(gpc_op op, gpc_polygon *subj, gpc_polygon *clip,
 			edge->outp[ABOVE]= cf->outp[ABOVE];
 			if (xb != cf->xb)
 			  VERTEX(edge, ABOVE, RIGHT, xb, yb);
-			cf= NULL;
+			cf= nullptr;
 			break;
 		  case ELI:
 			VERTEX(edge, BELOW, LEFT, xb, yb);
-			edge->outp[ABOVE]= NULL;
+			edge->outp[ABOVE]= nullptr;
 			cf= edge;
 			break;
 		  case EMX:
 			if (xb != cf->xb)
 			  VERTEX(edge, BELOW, RIGHT, xb, yb);
-			edge->outp[ABOVE]= NULL;
-			cf= NULL;
+			edge->outp[ABOVE]= nullptr;
+			cf= nullptr;
 			break;
 		  case IMN:
 			if (cft == LED)
@@ -2055,11 +2055,11 @@ void gpc_tristrip_clip(gpc_op op, gpc_polygon *subj, gpc_polygon *clip,
 			  new_tristrip(&tlist, cf, cf->xb, yb);
 		}
 			VERTEX(edge, BELOW, RIGHT, xb, yb);
-			edge->outp[ABOVE]= NULL;
+			edge->outp[ABOVE]= nullptr;
 			break;
 		  case IMX:
 			VERTEX(edge, BELOW, LEFT, xb, yb);
-			edge->outp[ABOVE]= NULL;
+			edge->outp[ABOVE]= nullptr;
 			cft= IMX;
 			break;
 	  case IMM:
@@ -2071,7 +2071,7 @@ void gpc_tristrip_clip(gpc_op op, gpc_polygon *subj, gpc_polygon *clip,
 			break;
 		  case EMM:
 			VERTEX(edge, BELOW, RIGHT, xb, yb);
-			edge->outp[ABOVE]= NULL;
+			edge->outp[ABOVE]= nullptr;
 			new_tristrip(&tlist, edge, xb, yb);
 			cf= edge;
 			break;
@@ -2104,7 +2104,7 @@ void gpc_tristrip_clip(gpc_op op, gpc_polygon *subj, gpc_polygon *clip,
 			  VERTEX(edge, BELOW, RIGHT, xb, yb);
 			  VERTEX(edge, ABOVE, RIGHT, xb, yb);
 		}
-			cf= NULL;
+			cf= nullptr;
 			break;
 		  default:
 			break;
@@ -2230,7 +2230,7 @@ void gpc_tristrip_clip(gpc_op op, gpc_polygon *subj, gpc_polygon *clip,
 			  VERTEX(prev_edge, ABOVE, LEFT, px, iy);
 			  VERTEX(e0, ABOVE, RIGHT, ix, iy);
 			  e1->outp[ABOVE]= e0->outp[ABOVE];
-			  e0->outp[ABOVE]= NULL;
+			  e0->outp[ABOVE]= nullptr;
 			}
 			break;
 		  case ELI:
@@ -2240,15 +2240,15 @@ void gpc_tristrip_clip(gpc_op op, gpc_polygon *subj, gpc_polygon *clip,
 			  VERTEX(e1, ABOVE, LEFT, ix, iy);
 			  VERTEX(next_edge, ABOVE, RIGHT, nx, iy);
 			  e0->outp[ABOVE]= e1->outp[ABOVE];
-			  e1->outp[ABOVE]= NULL;
+			  e1->outp[ABOVE]= nullptr;
 			}
 			break;
 		  case EMX:
 			if (p && q)
 			{
 			  VERTEX(e0, ABOVE, LEFT, ix, iy);
-			  e0->outp[ABOVE]= NULL;
-			  e1->outp[ABOVE]= NULL;
+			  e0->outp[ABOVE]= nullptr;
+			  e1->outp[ABOVE]= nullptr;
 			}
 			break;
 		  case IMN:
@@ -2270,7 +2270,7 @@ void gpc_tristrip_clip(gpc_op op, gpc_polygon *subj, gpc_polygon *clip,
 			  N_EDGE(next_edge, e1, ABOVE, nx, iy);
 			  VERTEX(next_edge, ABOVE, RIGHT, nx, iy);
 			  e1->outp[ABOVE]= e0->outp[ABOVE];
-			  e0->outp[ABOVE]= NULL;
+			  e0->outp[ABOVE]= nullptr;
 			}
 			break;
 		  case IRI:
@@ -2280,7 +2280,7 @@ void gpc_tristrip_clip(gpc_op op, gpc_polygon *subj, gpc_polygon *clip,
 			  P_EDGE(prev_edge, e0, ABOVE, px, iy);
 			  VERTEX(prev_edge, ABOVE, LEFT, px, iy);
 			  e0->outp[ABOVE]= e1->outp[ABOVE];
-			  e1->outp[ABOVE]= NULL;
+			  e1->outp[ABOVE]= nullptr;
 			}
 			break;
 		  case IMX:
@@ -2288,8 +2288,8 @@ void gpc_tristrip_clip(gpc_op op, gpc_polygon *subj, gpc_polygon *clip,
 			{
 			  VERTEX(e0, ABOVE, RIGHT, ix, iy);
 			  VERTEX(e1, ABOVE, LEFT, ix, iy);
-			  e0->outp[ABOVE]= NULL;
-			  e1->outp[ABOVE]= NULL;
+			  e0->outp[ABOVE]= nullptr;
+			  e1->outp[ABOVE]= nullptr;
 			  P_EDGE(prev_edge, e0, ABOVE, px, iy);
 			  VERTEX(prev_edge, ABOVE, LEFT, px, iy);
 			  new_tristrip(&tlist, prev_edge, px, iy);
@@ -2409,13 +2409,13 @@ void gpc_tristrip_clip(gpc_op op, gpc_polygon *subj, gpc_polygon *clip,
 		  edge->bundle[BELOW][SUBJ]= edge->bundle[ABOVE][SUBJ];
 		  edge->xb= edge->xt;
 		}
-		edge->outp[ABOVE]= NULL;
+		edge->outp[ABOVE]= nullptr;
 	  }
 	}
   } /* === END OF SCANBEAM PROCESSING ================================== */
 
   /* Generate result tristrip from tlist */
-  result->strip= NULL;
+  result->strip= nullptr;
   result->num_strips= count_tristrips(tlist);
   if (result->num_strips > 0)
   {

--- a/QGLViewer/camera.cpp
+++ b/QGLViewer/camera.cpp
@@ -14,7 +14,7 @@ using namespace qglviewer;
  See IODistance(), physicalDistanceToScreen(), physicalScreenWidth() and
  focusDistance() documentations for default stereo parameter values. */
 Camera::Camera()
-    : frame_(NULL), fieldOfView_(M_PI / 4.0), modelViewMatrixIsUpToDate_(false),
+    : frame_(nullptr), fieldOfView_(M_PI / 4.0), modelViewMatrixIsUpToDate_(false),
       projectionMatrixIsUpToDate_(false) {
   // #CONNECTION# Camera copy constructor
   interpolationKfi_ = new KeyFrameInterpolator;
@@ -69,7 +69,7 @@ Camera::~Camera() {
 }
 
 /*! Copy constructor. Performs a deep copy using operator=(). */
-Camera::Camera(const Camera &camera) : QObject(), frame_(NULL) {
+Camera::Camera(const Camera &camera) : QObject(), frame_(nullptr) {
   // #CONNECTION# Camera constructor
   interpolationKfi_ = new KeyFrameInterpolator;
   // Requires the interpolationKfi_
@@ -116,7 +116,7 @@ Camera &Camera::operator=(const Camera &camera) {
   projectionMatrixIsUpToDate_ = false;
 
   // frame_ and interpolationKfi_ pointers are not shared.
-  frame_->setReferenceFrame(NULL);
+  frame_->setReferenceFrame(nullptr);
   frame_->setPosition(camera.position());
   frame_->setOrientation(camera.orientation());
 
@@ -259,7 +259,7 @@ either. Use addKeyFrameToPath() and playPath() instead.
 This method is actually mainly useful if you derive the ManipulatedCameraFrame
 class and want to use an instance of your new class to move the Camera.
 
-A \c NULL \p mcf pointer will silently be ignored. The calling method is
+A \c nullptr \p mcf pointer will silently be ignored. The calling method is
 responsible for deleting the previous frame() pointer if needed in order to
 prevent memory leaks. */
 void Camera::setFrame(ManipulatedCameraFrame *const mcf) {
@@ -964,8 +964,8 @@ Vec Camera::pointUnderPixel(const QPoint &pixel, bool &found) const {
   // Qt uses upper corner for its origin while GL uses the lower corner.
   glReadPixels(pixel.x(), screenHeight() - 1 - pixel.y(), 1, 1,
                GL_DEPTH_COMPONENT, GL_FLOAT, &depth);
-  found = depth < 1.0;
-  Vec point(pixel.x(), pixel.y(), depth);
+  found = static_cast<double>(depth)< 1.0;
+  Vec point(pixel.x(), pixel.y(), static_cast<double>(depth));
   point = unprojectedCoordinatesOf(point);
   return point;
 }
@@ -1512,7 +1512,7 @@ void Camera::getViewport(GLint viewport[4]) const {
 /*! Returns the screen projected coordinates of a point \p src defined in the \p
  frame coordinate system.
 
- When \p frame in \c NULL (default), \p src is expressed in the world coordinate
+ When \p frame in \c nullptr (default), \p src is expressed in the world coordinate
  system.
 
  The x and y coordinates of the returned Vec are expressed in pixel, (0,0) being
@@ -1615,7 +1615,7 @@ Vec Camera::projectedCoordinatesOf(const Vec &src, const Frame *frame) const {
  gluUnProject man page for details.
 
  The result is expressed in the \p frame coordinate system. When \p frame is \c
- NULL (default), the result is expressed in the world coordinates system. The
+ nullptr (default), the result is expressed in the world coordinates system. The
  possible \p frame Frame::referenceFrame() are taken into account.
 
  projectedCoordinatesOf() performs the inverse transformation.
@@ -1670,13 +1670,13 @@ void Camera::getUnprojectedCoordinatesOf(const qreal src[3], qreal res[3],
 
 /*! Returns the KeyFrameInterpolator that defines the Camera path number \p i.
 
-If path \p i is not defined for this index, the method returns a \c NULL
+If path \p i is not defined for this index, the method returns a \c nullptr
 pointer. */
 KeyFrameInterpolator *Camera::keyFrameInterpolator(unsigned int i) const {
   if (kfi_.contains(i))
     return kfi_[i];
   else
-    return NULL;
+    return nullptr;
 }
 
 /*! Sets the KeyFrameInterpolator that defines the Camera path of index \p i.

--- a/QGLViewer/camera.h
+++ b/QGLViewer/camera.h
@@ -407,12 +407,12 @@ public:
   /*! @name 2D screen to 3D world coordinate systems conversions */
   //@{
 public:
-  Vec projectedCoordinatesOf(const Vec &src, const Frame *frame = NULL) const;
-  Vec unprojectedCoordinatesOf(const Vec &src, const Frame *frame = NULL) const;
+  Vec projectedCoordinatesOf(const Vec &src, const Frame *frame = nullptr) const;
+  Vec unprojectedCoordinatesOf(const Vec &src, const Frame *frame = nullptr) const;
   void getProjectedCoordinatesOf(const qreal src[3], qreal res[3],
-                                 const Frame *frame = NULL) const;
+                                 const Frame *frame = nullptr) const;
   void getUnprojectedCoordinatesOf(const qreal src[3], qreal res[3],
-                                   const Frame *frame = NULL) const;
+                                   const Frame *frame = nullptr) const;
   void convertClickToLine(const QPoint &pixel, Vec &orig, Vec &dir) const;
   Vec pointUnderPixel(const QPoint &pixel, bool &found) const;
   //@}

--- a/QGLViewer/constraint.h
+++ b/QGLViewer/constraint.h
@@ -13,7 +13,7 @@ class Camera;
 
   This class defines the interface for the Constraints that can be applied to a
   Frame to limit its motion. Use Frame::setConstraint() to associate a
-  Constraint to a Frame (default is a \c NULL Frame::constraint()).
+  Constraint to a Frame (default is a \c nullptr Frame::constraint()).
 
   <h3>How does it work ?</h3>
 

--- a/QGLViewer/frame.cpp
+++ b/QGLViewer/frame.cpp
@@ -8,8 +8,8 @@ using namespace std;
 /*! Creates a default Frame.
 
   Its position() is (0,0,0) and it has an identity orientation() Quaternion. The
-  referenceFrame() and the constraint() are \c NULL. */
-Frame::Frame() : constraint_(NULL), referenceFrame_(NULL) {}
+  referenceFrame() and the constraint() are \c nullptr. */
+Frame::Frame() : constraint_(nullptr), referenceFrame_(nullptr) {}
 
 /*! Creates a Frame with a position() and an orientation().
 
@@ -17,9 +17,9 @@ Frame::Frame() : constraint_(NULL), referenceFrame_(NULL) {}
  methods.
 
  The Frame is defined in the world coordinate system (its referenceFrame() is \c
- NULL). It has a \c NULL associated constraint(). */
+ nullptr). It has a \c nullptr associated constraint(). */
 Frame::Frame(const Vec &position, const Quaternion &orientation)
-    : t_(position), q_(orientation), constraint_(NULL), referenceFrame_(NULL) {}
+    : t_(position), q_(orientation), constraint_(nullptr), referenceFrame_(nullptr) {}
 
 /*! Equal operator.
 
@@ -83,7 +83,7 @@ Frame::Frame(const Frame &frame) : QObject() { (*this) = frame; }
   This matrix only represents the local Frame transformation (i.e. with respect
   to the referenceFrame()). Use worldMatrix() to get the full Frame
   transformation matrix (i.e. from the world to the Frame coordinate system).
-  These two match when the referenceFrame() is \c NULL.
+  These two match when the referenceFrame() is \c nullptr.
 
   The result is only valid until the next call to matrix(), getMatrix(),
   worldMatrix() or getWorldMatrix(). Use it immediately (as above) or use
@@ -132,7 +132,7 @@ void Frame::getMatrix(GLdouble m[16]) const {
   Only the local Frame transformation (i.e. defined with respect to the
   referenceFrame()) is inverted. Use worldInverse() for a global inverse.
 
-  The resulting Frame has the same referenceFrame() as the Frame and a \c NULL
+  The resulting Frame has the same referenceFrame() as the Frame and a \c nullptr
   constraint().
 
   \note The scaling factor of the 4x4 matrix is 1.0. */
@@ -159,7 +159,7 @@ Frame Frame::inverse() const {
   referenceFrame() hierarchy is taken into account to define the Frame
   transformation from the world coordinate system. Use matrix() to get the local
   Frame transformation matrix (i.e. defined with respect to the
-  referenceFrame()). These two match when the referenceFrame() is \c NULL.
+  referenceFrame()). These two match when the referenceFrame() is \c nullptr.
 
   The OpenGL format of the result is the transpose of the actual mathematical
   European representation (translation is on the last \e line instead of the
@@ -506,7 +506,7 @@ Vec Frame::position() const {
 Quaternion Frame::orientation() const {
   Quaternion res = rotation();
   const Frame *fr = referenceFrame();
-  while (fr != NULL) {
+  while (fr != nullptr) {
     res = fr->rotation() * res;
     fr = fr->referenceFrame();
   }
@@ -617,7 +617,7 @@ Emits the modified() signal if \p refFrame differs from the current
 referenceFrame().
 
 Using this method, you can create a hierarchy of Frames. This hierarchy needs to
-be a tree, which root is the world coordinate system (i.e. a \c NULL
+be a tree, which root is the world coordinate system (i.e. a \c nullptr
 referenceFrame()). A warning is printed and no action is performed if setting \p
 refFrame as the referenceFrame() would create a loop in the Frame hierarchy (see
 settingAsReferenceFrameWillCreateALoop()). */
@@ -636,7 +636,7 @@ void Frame::setReferenceFrame(const Frame *const refFrame) {
   create a loop in the Frame hierarchy. */
 bool Frame::settingAsReferenceFrameWillCreateALoop(const Frame *const frame) {
   const Frame *f = frame;
-  while (f != NULL) {
+  while (f != nullptr) {
     if (f == this)
       return true;
     f = f->referenceFrame();
@@ -670,7 +670,7 @@ Vec Frame::coordinatesOf(const Vec &src) const {
 Vec Frame::inverseCoordinatesOf(const Vec &src) const {
   const Frame *fr = this;
   Vec res = src;
-  while (fr != NULL) {
+  while (fr != nullptr) {
     res = fr->localInverseCoordinatesOf(res);
     fr = fr->referenceFrame();
   }
@@ -715,7 +715,7 @@ Vec Frame::coordinatesOfFrom(const Vec &src, const Frame *const from) const {
 Vec Frame::coordinatesOfIn(const Vec &src, const Frame *const in) const {
   const Frame *fr = this;
   Vec res = src;
-  while ((fr != NULL) && (fr != in)) {
+  while ((fr != nullptr) && (fr != in)) {
     res = fr->localInverseCoordinatesOf(res);
     fr = fr->referenceFrame();
   }
@@ -802,7 +802,7 @@ Vec Frame::transformOf(const Vec &src) const {
 Vec Frame::inverseTransformOf(const Vec &src) const {
   const Frame *fr = this;
   Vec res = src;
-  while (fr != NULL) {
+  while (fr != nullptr) {
     res = fr->localInverseTransformOf(res);
     fr = fr->referenceFrame();
   }
@@ -848,7 +848,7 @@ Vec Frame::transformOfFrom(const Vec &src, const Frame *const from) const {
 Vec Frame::transformOfIn(const Vec &src, const Frame *const in) const {
   const Frame *fr = this;
   Vec res = src;
-  while ((fr != NULL) && (fr != in)) {
+  while ((fr != nullptr) && (fr != in)) {
     res = fr->localInverseTransformOf(res);
     fr = fr->referenceFrame();
   }
@@ -988,7 +988,7 @@ alignment. The new Frame's position() is such that the \p frame position
 (computed with coordinatesOf(), in the Frame coordinates system) does not
 change.
 
-\p frame may be \c NULL and then represents the world coordinate system (same
+\p frame may be \c nullptr and then represents the world coordinate system (same
 convention than for the referenceFrame()).
 
 The rotation (and translation when \p move is \c true) applied to the Frame are

--- a/QGLViewer/frame.h
+++ b/QGLViewer/frame.h
@@ -48,7 +48,7 @@ namespace qglviewer {
 
   The position and the orientation of a Frame are actually defined with respect
   to a referenceFrame(). The default referenceFrame() is the world coordinate
-  system (represented by a \c NULL referenceFrame()). If you setReferenceFrame()
+  system (represented by a \c nullptr referenceFrame()). If you setReferenceFrame()
   to a different Frame, you must then differentiate:
 
   \arg the \e local translation() and rotation(), defined with respect to the
@@ -64,7 +64,7 @@ namespace qglviewer {
   This terminology for \e local (translation() and rotation()) and \e global
   (position() and orientation()) definitions is used in all the methods' names
   and should be sufficient to prevent ambiguities. These notions are obviously
-  identical when the referenceFrame() is \c NULL, i.e. when the Frame is defined
+  identical when the referenceFrame() is \c nullptr, i.e. when the Frame is defined
   in the world coordinate system (the one you are in at the beginning of the
   QGLViewer::draw() method, see the <a href="../introduction.html">introduction
   page</a>).
@@ -89,7 +89,7 @@ namespace qglviewer {
   An interesting feature of Frames is that their displacements can be
   constrained. When a Constraint is attached to a Frame, it filters the input of
   translate() and rotate(), and only the resulting filtered motion is applied to
-  the Frame. The default constraint() is \c NULL resulting in no filtering. Use
+  the Frame. The default constraint() is \c nullptr resulting in no filtering. Use
   setConstraint() to attach a Constraint to a frame.
 
   Constraints are especially usefull for the ManipulatedFrame instances, in
@@ -134,7 +134,7 @@ Q_SIGNALS:
   \note If your Frame is part of a Frame hierarchy (see referenceFrame()), a
   modification of one of the parents of this Frame will \e not emit this signal.
   Use code like this to change this behavior (you can do this recursively for
-  all the referenceFrame() until the \c NULL world root frame is encountered):
+  all the referenceFrame() until the \c nullptr world root frame is encountered):
   \code
   // Emits the Frame modified() signal when its referenceFrame() is modified().
   connect(myFrame->referenceFrame(), SIGNAL(modified()), myFrame,
@@ -227,14 +227,14 @@ public:
   referenceFrame().
 
   Use position() to get the result in the world coordinates. These two values
-  are identical when the referenceFrame() is \c NULL (default).
+  are identical when the referenceFrame() is \c nullptr (default).
 
   See also setTranslation() and setTranslationWithConstraint(). */
   Vec translation() const { return t_; }
   /*! Returns the Frame rotation, defined with respect to the referenceFrame().
 
   Use orientation() to get the result in the world coordinates. These two values
-  are identical when the referenceFrame() is \c NULL (default).
+  are identical when the referenceFrame() is \c nullptr (default).
 
   See also setRotation() and setRotationWithConstraint(). */
 
@@ -252,12 +252,12 @@ public:
   defined.
 
   The translation() and rotation() of the Frame are defined with respect to the
-  referenceFrame() coordinate system. A \c NULL referenceFrame() (default value)
+  referenceFrame() coordinate system. A \c nullptr referenceFrame() (default value)
   means that the Frame is defined in the world coordinate system.
 
   Use position() and orientation() to recursively convert values along the
   referenceFrame() chain and to get values expressed in the world coordinate
-  system. The values match when the referenceFrame() is \c NULL.
+  system. The values match when the referenceFrame() is \c nullptr.
 
   Use setReferenceFrame() to set this value and create a Frame hierarchy.
   Convenient functions allow you to convert 3D coordinates from one Frame to an
@@ -337,7 +337,7 @@ public:
 
   // When In (resp. From) is appended to the names, the functions transform from
   // (resp. To) the frame that is given as an argument. The frame does not need
-  // to be in the same branch or the hierarchical tree, and can be \c NULL (the
+  // to be in the same branch or the hierarchical tree, and can be \c nullptr (the
   // world coordinates system).
 
   // Combining any of these functions with its inverse (in any order) leads to
@@ -364,7 +364,7 @@ public:
   //@{
   /*! Returns the current constraint applied to the Frame.
 
-  A \c NULL value (default) means that no Constraint is used to filter Frame
+  A \c nullptr value (default) means that no Constraint is used to filter Frame
   translation and rotation. See the Constraint class documentation for details.
 
   You may have to use a \c dynamic_cast to convert the result to a Constraint
@@ -372,7 +372,7 @@ public:
   Constraint *constraint() const { return constraint_; }
   /*! Sets the constraint() attached to the Frame.
 
-  A \c NULL value means no constraint. The previous constraint() should be
+  A \c nullptr value means no constraint. The previous constraint() should be
   deleted by the calling method if needed. */
   void setConstraint(Constraint *const constraint) { constraint_ = constraint; }
   //@}
@@ -401,7 +401,7 @@ public:
   original orientation. Its position() is the negated and inverse rotated image
   of the original position.
 
-  The result Frame has a \c NULL referenceFrame() and a \c NULL constraint().
+  The result Frame has a \c nullptr referenceFrame() and a \c nullptr constraint().
 
   Use inverse() for a local (i.e. with respect to referenceFrame())
   transformation inverse. */

--- a/QGLViewer/keyFrameInterpolator.cpp
+++ b/QGLViewer/keyFrameInterpolator.cpp
@@ -11,7 +11,7 @@ using namespace std;
   interpolationTime(), interpolationSpeed() and interpolationPeriod() are set to
   their default values. */
 KeyFrameInterpolator::KeyFrameInterpolator(Frame *frame)
-    : frame_(NULL), period_(40), interpolationTime_(0.0),
+    : frame_(nullptr), period_(40), interpolationTime_(0.0),
       interpolationSpeed_(1.0), interpolationStarted_(false),
       closedPath_(false), loopInterpolation_(false), pathIsValid_(false),
       valuesAreValid_(true), currentFrameValid_(false)
@@ -145,7 +145,7 @@ void KeyFrameInterpolator::resetInterpolation() {
   edited, even during the interpolation. See the <a
   href="../examples/keyFrames.html">keyFrames example</a> for an illustration.
 
-  \c NULL \p frame pointers are silently ignored. The keyFrameTime() has to be
+  \c nullptr \p frame pointers are silently ignored. The keyFrameTime() has to be
   monotonously increasing over keyFrames.
 
   Use addKeyFrame(const Frame&, qreal) to add keyFrame by values. */
@@ -331,9 +331,9 @@ void KeyFrameInterpolator::drawPath(int mask, int nbFrames, qreal scale) {
       kf_[0] = keyFrame_.first();
       kf_[1] = kf_[0];
       int index = 1;
-      kf_[2] = (index < keyFrame_.size()) ? keyFrame_.at(index) : NULL;
+      kf_[2] = (index < keyFrame_.size()) ? keyFrame_.at(index) : nullptr;
       index++;
-      kf_[3] = (index < keyFrame_.size()) ? keyFrame_.at(index) : NULL;
+      kf_[3] = (index < keyFrame_.size()) ? keyFrame_.at(index) : nullptr;
 
       while (kf_[2]) {
         Vec diff = kf_[2]->position() - kf_[1]->position();
@@ -357,7 +357,7 @@ void KeyFrameInterpolator::drawPath(int mask, int nbFrames, qreal scale) {
         kf_[1] = kf_[2];
         kf_[2] = kf_[3];
         index++;
-        kf_[3] = (index < keyFrame_.size()) ? keyFrame_.at(index) : NULL;
+        kf_[3] = (index < keyFrame_.size()) ? keyFrame_.at(index) : nullptr;
       }
       // Add last KeyFrame
       path_.push_back(Frame(kf_[1]->position(), kf_[1]->orientation()));
@@ -410,7 +410,7 @@ void KeyFrameInterpolator::updateModifiedFrameValues() {
   kf = keyFrame_.first();
   int index = 1;
   while (kf) {
-    KeyFrame *next = (index < keyFrame_.size()) ? keyFrame_.at(index) : NULL;
+    KeyFrame *next = (index < keyFrame_.size()) ? keyFrame_.at(index) : nullptr;
     index++;
     if (next)
       kf->computeTangent(prev, next);
@@ -647,7 +647,7 @@ void KeyFrameInterpolator::initFromDOMElement(const QDomElement &element) {
   setClosedPath(DomUtils::boolFromDom(element, "closedPath", false));
   setLoopInterpolation(DomUtils::boolFromDom(element, "loop", false));
 
-  // setFrame(NULL);
+  // setFrame(nullptr);
   pathIsValid_ = false;
   valuesAreValid_ = false;
   currentFrameValid_ = false;
@@ -659,7 +659,7 @@ void KeyFrameInterpolator::initFromDOMElement(const QDomElement &element) {
 
 //////////// KeyFrame private class implementation /////////
 KeyFrameInterpolator::KeyFrame::KeyFrame(const Frame &fr, qreal t)
-    : time_(t), frame_(NULL) {
+    : time_(t), frame_(nullptr) {
   p_ = fr.position();
   q_ = fr.orientation();
 }

--- a/QGLViewer/keyFrameInterpolator.h
+++ b/QGLViewer/keyFrameInterpolator.h
@@ -112,7 +112,7 @@ class QGLVIEWER_EXPORT KeyFrameInterpolator : public QObject {
   Q_OBJECT
 
 public:
-  KeyFrameInterpolator(Frame *fr = NULL);
+  KeyFrameInterpolator(Frame *fr = nullptr);
   virtual ~KeyFrameInterpolator();
 
 Q_SIGNALS:

--- a/QGLViewer/manipulatedFrame.cpp
+++ b/QGLViewer/manipulatedFrame.cpp
@@ -29,7 +29,7 @@ ManipulatedFrame::ManipulatedFrame()
   setZoomSensitivity(1.0);
 
   isSpinning_ = false;
-  previousConstraint_ = NULL;
+  previousConstraint_ = nullptr;
 
   connect(&spinningTimer_, SIGNAL(timeout()), SLOT(spinUpdate()));
 }
@@ -118,7 +118,7 @@ restored and are left unchanged.
 
 See Vec::initFromDOMElement() for a complete code example. */
 void ManipulatedFrame::initFromDOMElement(const QDomElement &element) {
-  // Not called since it would set constraint() and referenceFrame() to NULL.
+  // Not called since it would set constraint() and referenceFrame() to nullptr.
   // *this = ManipulatedFrame();
   Frame::initFromDOMElement(element);
 
@@ -183,16 +183,16 @@ void ManipulatedFrame::spinUpdate() {
 #ifndef DOXYGEN
 /*! Protected internal method used to handle mouse events. */
 void ManipulatedFrame::startAction(int ma, bool withConstraint) {
-  action_ = (QGLViewer::MouseAction)(ma);
+  action_ = static_cast<QGLViewer::MouseAction>(ma);
 
   // #CONNECTION# manipulatedFrame::wheelEvent,
   // manipulatedCameraFrame::wheelEvent and mouseReleaseEvent() restore previous
   // constraint
   if (withConstraint)
-    previousConstraint_ = NULL;
+    previousConstraint_ = nullptr;
   else {
     previousConstraint_ = constraint();
-    setConstraint(NULL);
+    setConstraint(nullptr);
   }
 
   switch (action_) {
@@ -281,7 +281,7 @@ The mouse behavior depends on which button is pressed. See the <a
 href="../mouse.html">QGLViewer mouse page</a> for details. */
 void ManipulatedFrame::mousePressEvent(QMouseEvent *const event,
                                        Camera *const camera) {
-  Q_UNUSED(camera);
+  Q_UNUSED(camera)
 
   if (grabsMouse())
     keepsGrabbingMouse_ = true;
@@ -440,8 +440,8 @@ spinningSensitivity() when the button is released. Press the rotate button again
 to stop spinning. See startSpinning() and isSpinning(). */
 void ManipulatedFrame::mouseReleaseEvent(QMouseEvent *const event,
                                          Camera *const camera) {
-  Q_UNUSED(event);
-  Q_UNUSED(camera);
+  Q_UNUSED(event)
+  Q_UNUSED(camera)
 
   keepsGrabbingMouse_ = false;
 

--- a/QGLViewer/qglviewer.cpp
+++ b/QGLViewer/qglviewer.cpp
@@ -53,7 +53,7 @@ void QGLViewer::defaultConstructor() {
   // qWarning("Unable to get OpenGL version, context may not be available -
   // Check your configuration");
 
-  int poolIndex = QGLViewer::QGLViewerPool_.indexOf(NULL);
+  int poolIndex = QGLViewer::QGLViewerPool_.indexOf(nullptr);
   setFocusPolicy(Qt::StrongFocus);
 
   if (poolIndex >= 0)
@@ -83,15 +83,15 @@ void QGLViewer::defaultConstructor() {
   // setFullScreen(true)
 
   // #CONNECTION# default values in initFromDOMElement()
-  manipulatedFrame_ = NULL;
+  manipulatedFrame_ = nullptr;
   manipulatedFrameIsACamera_ = false;
   mouseGrabberIsAManipulatedFrame_ = false;
   mouseGrabberIsAManipulatedCameraFrame_ = false;
   displayMessage_ = false;
   connect(&messageTimer_, SIGNAL(timeout()), SLOT(hideMessage()));
   messageTimer_.setSingleShot(true);
-  helpWidget_ = NULL;
-  setMouseGrabber(NULL);
+  helpWidget_ = nullptr;
+  setMouseGrabber(nullptr);
 
   setSceneRadius(1.0);
   showEntireScene();
@@ -112,7 +112,7 @@ void QGLViewer::defaultConstructor() {
   stopAnimation();
   setAnimationPeriod(40); // 25Hz
 
-  selectBuffer_ = NULL;
+  selectBuffer_ = nullptr;
   setSelectBufferSize(4 * 1000);
   setSelectRegionWidth(3);
   setSelectRegionHeight(3);
@@ -129,7 +129,7 @@ void QGLViewer::defaultConstructor() {
 
   setAttribute(Qt::WA_NoSystemBackground);
 
-  tileRegion_ = NULL;
+  tileRegion_ = nullptr;
 }
 
 /*! Constructor. See \c QGLWidget documentation for details.
@@ -155,7 +155,7 @@ will share the OpenGL context with \p shareWidget (see isSharing()). */
 QGLViewer::QGLViewer(QWidget *parent, const QGLWidget *shareWidget,
                      Qt::WindowFlags flags)
     : QOpenGLWidget(parent, flags) {
-  Q_UNUSED(shareWidget);
+  Q_UNUSED(shareWidget)
   qWarning("The constructor with a shareWidget is deprecated, use the regular "
            "contructor instead.");
   defaultConstructor();
@@ -167,8 +167,8 @@ otherwise). */
 QGLViewer::QGLViewer(QGLContext *context, QWidget *parent,
                      const QGLWidget *shareWidget, Qt::WindowFlags flags)
     : QOpenGLWidget(parent, flags) {
-  Q_UNUSED(context);
-  Q_UNUSED(shareWidget);
+  Q_UNUSED(context)
+  Q_UNUSED(shareWidget)
   qWarning("The constructor with a QGLContext is deprecated, use the regular "
            "contructor instead.");
   defaultConstructor();
@@ -182,8 +182,8 @@ example</a>). */
 QGLViewer::QGLViewer(const QGLFormat &format, QWidget *parent,
                      const QGLWidget *shareWidget, Qt::WindowFlags flags)
     : QOpenGLWidget(parent, flags) {
-  Q_UNUSED(format);
-  Q_UNUSED(shareWidget);
+  Q_UNUSED(format)
+  Q_UNUSED(shareWidget)
   qWarning("The constructor with a QGLFormat is deprecated, use the regular "
            "contructor instead.");
   defaultConstructor();
@@ -192,7 +192,7 @@ QGLViewer::QGLViewer(const QGLFormat &format, QWidget *parent,
 
 /*! Virtual destructor.
 
-The viewer is replaced by \c NULL in the QGLViewerPool() (in order to preserve
+The viewer is replaced by \c nullptr in the QGLViewerPool() (in order to preserve
 other viewer's indexes) and allocated memory is released. The camera() is
 deleted and should be copied before if it is shared by an other viewer. */
 QGLViewer::~QGLViewer() {
@@ -202,7 +202,7 @@ QGLViewer::~QGLViewer() {
   // saveStateToFileForAllViewers();
 
   QGLViewer::QGLViewerPool_.replace(QGLViewer::QGLViewerPool_.indexOf(this),
-                                    NULL);
+                                    nullptr);
 
   delete camera();
   delete[] selectBuffer_;
@@ -568,7 +568,7 @@ void QGLViewer::setDefaultMouseBindings() {
 
   //#CONNECTION# toggleCameraMode()
   for (int handler = 0; handler < 2; ++handler) {
-    MouseHandler mh = (MouseHandler)(handler);
+    MouseHandler mh = static_cast<MouseHandler>(handler);
     Qt::KeyboardModifiers modifiers =
         (mh == FRAME) ? frameKeyboardModifiers : cameraKeyboardModifiers;
 
@@ -628,7 +628,7 @@ It you simply want to save and restore Camera positions, use
 qglviewer::Camera::addKeyFrameToPath() and qglviewer::Camera::playPath()
 instead.
 
-This method silently ignores \c NULL \p camera pointers. The calling method is
+This method silently ignores \c nullptr \p camera pointers. The calling method is
 responsible for deleting the previous camera pointer in order to prevent memory
 leaks if needed.
 
@@ -721,23 +721,23 @@ void QGLViewer::drawLight(GLenum light, qreal scale) const {
     float pos[4];
     glGetLightfv(light, GL_POSITION, pos);
 
-    if (pos[3] != 0.0) {
+    if (static_cast<double>(pos[3]) != 0.0) {
       glTranslatef(pos[0] / pos[3], pos[1] / pos[3], pos[2] / pos[3]);
 
       GLfloat cutOff;
       glGetLightfv(light, GL_SPOT_CUTOFF, &cutOff);
-      if (cutOff != 180.0) {
+      if (static_cast<double>(cutOff) != 180.0) {
         GLfloat dir[4];
         glGetLightfv(light, GL_SPOT_DIRECTION, dir);
         glMultMatrixd(Quaternion(Vec(0, 0, 1), Vec(dir)).matrix());
         QGLViewer::drawArrow(length);
-        gluCylinder(quadric, 0.0, 0.7 * length * sin(cutOff * M_PI / 180.0),
-                    0.7 * length * cos(cutOff * M_PI / 180.0), 12, 1);
+        gluCylinder(quadric, 0.0, 0.7 * length * sin(static_cast<double>(cutOff) * M_PI / 180.0),
+                    0.7 * length * cos(static_cast<double>(cutOff) * M_PI / 180.0), 12, 1);
       } else
         gluSphere(quadric, 0.2 * length, 10, 10);
     } else {
       // Directional light.
-      Vec dir(pos[0], pos[1], pos[2]);
+      Vec dir(static_cast<double>(pos[0]), static_cast<double>(pos[1]), static_cast<double>(pos[2]));
       dir.normalize();
       Frame fr =
           Frame(camera()->cameraCoordinatesOf(
@@ -810,7 +810,7 @@ void QGLViewer::drawText(int x, int y, const QString &text, const QFont &fnt) {
   if (!textIsEnabled())
     return;
 
-  if (tileRegion_ != NULL) {
+  if (tileRegion_ != nullptr) {
     renderText(int((x - tileRegion_->xMin) * width() /
                    (tileRegion_->xMax - tileRegion_->xMin)),
                int((y - tileRegion_->yMin) * height() /
@@ -906,7 +906,7 @@ void QGLViewer::startScreenCoordinatesSystem(bool upward) const {
   glMatrixMode(GL_PROJECTION);
   glPushMatrix();
   glLoadIdentity();
-  if (tileRegion_ != NULL)
+  if (tileRegion_ != nullptr)
     if (upward)
       glOrtho(tileRegion_->xMin, tileRegion_->xMax, tileRegion_->yMin,
               tileRegion_->yMax, 0.0, -1.0);
@@ -1160,7 +1160,7 @@ setSelectedName((selectBuffer())[i*4+3])
 See the <a href="../examples/multiSelect.html">multiSelect example</a> for
 a multi-object selection implementation of this method. */
 void QGLViewer::endSelection(const QPoint &point) {
-  Q_UNUSED(point);
+  Q_UNUSED(point)
 
   // Flush GL buffers
   glFlush();
@@ -1294,7 +1294,7 @@ void QGLViewer::mousePressEvent(QMouseEvent *e) {
   //#CONNECTION# mouseString() concatenates bindings description in inverse
   // order.
   ClickBindingPrivate cbp(e->modifiers(), e->button(), false,
-                          (Qt::MouseButtons)(e->buttons() & ~(e->button())),
+                          static_cast<Qt::MouseButtons>((e->buttons() & ~(e->button()))),
                           currentlyPressedKey_);
 
   if (clickBinding_.contains(cbp)) {
@@ -1396,7 +1396,7 @@ void QGLViewer::mouseMoveEvent(QMouseEvent *e) {
       else
         mouseGrabber()->mouseMoveEvent(e, camera());
     else
-      setMouseGrabber(NULL);
+      setMouseGrabber(nullptr);
     update();
   }
 
@@ -1446,7 +1446,7 @@ void QGLViewer::mouseReleaseEvent(QMouseEvent *e) {
       mouseGrabber()->mouseReleaseEvent(e, camera());
     mouseGrabber()->checkIfGrabsMouse(e->x(), e->y(), camera());
     if (!(mouseGrabber()->grabsMouse()))
-      setMouseGrabber(NULL);
+      setMouseGrabber(nullptr);
     // update();
   } else
       //#CONNECTION# mouseMoveEvent has the same structure
@@ -1528,7 +1528,7 @@ setMouseBinding() and the <a href="../mouse.html">mouse page</a>. */
 void QGLViewer::mouseDoubleClickEvent(QMouseEvent *e) {
   //#CONNECTION# mousePressEvent has the same structure
   ClickBindingPrivate cbp(e->modifiers(), e->button(), true,
-                          (Qt::MouseButtons)(e->buttons() & ~(e->button())),
+                          static_cast<Qt::MouseButtons>(e->buttons() & ~(e->button())),
                           currentlyPressedKey_);
   if (clickBinding_.contains(cbp))
     performClickAction(clickBinding_[cbp], e);
@@ -1600,9 +1600,9 @@ void QGLViewer::setMouseGrabber(MouseGrabber *mouseGrabber) {
   mouseGrabber_ = mouseGrabber;
 
   mouseGrabberIsAManipulatedFrame_ =
-      (dynamic_cast<ManipulatedFrame *>(mouseGrabber) != NULL);
+      (dynamic_cast<ManipulatedFrame *>(mouseGrabber) != nullptr);
   mouseGrabberIsAManipulatedCameraFrame_ =
-      ((dynamic_cast<ManipulatedCameraFrame *>(mouseGrabber) != NULL) &&
+      ((dynamic_cast<ManipulatedCameraFrame *>(mouseGrabber) != nullptr) &&
        (mouseGrabber != camera()->frame()));
   Q_EMIT mouseGrabberChanged(mouseGrabber);
 }
@@ -1619,7 +1619,7 @@ void QGLViewer::setMouseGrabberIsEnabled(
 QString QGLViewer::mouseActionString(QGLViewer::MouseAction ma) {
   switch (ma) {
   case QGLViewer::NO_MOUSE_ACTION:
-    return QString::null;
+    return QString();
   case QGLViewer::ROTATE:
     return QGLViewer::tr("Rotates", "ROTATE mouse action");
   case QGLViewer::ZOOM:
@@ -1645,13 +1645,13 @@ QString QGLViewer::mouseActionString(QGLViewer::MouseAction ma) {
   case QGLViewer::ZOOM_ON_REGION:
     return QGLViewer::tr("Zooms on region for", "ZOOM_ON_REGION mouse action");
   }
-  return QString::null;
+  return QString();
 }
 
 QString QGLViewer::clickActionString(QGLViewer::ClickAction ca) {
   switch (ca) {
   case QGLViewer::NO_CLICK_ACTION:
-    return QString::null;
+    return QString();
   case QGLViewer::ZOOM_ON_PIXEL:
     return QGLViewer::tr("Zooms on pixel", "ZOOM_ON_PIXEL click action");
   case QGLViewer::ZOOM_TO_FIT:
@@ -1676,7 +1676,7 @@ QString QGLViewer::clickActionString(QGLViewer::ClickAction ca) {
   case QGLViewer::ALIGN_CAMERA:
     return QGLViewer::tr("Aligns camera", "ALIGN_CAMERA click action");
   }
-  return QString::null;
+  return QString();
 }
 
 static QString keyString(unsigned int key) {
@@ -1968,7 +1968,7 @@ void QGLViewer::setKeyDescription(unsigned int key, QString description) {
 
 QString QGLViewer::cameraPathKeysString() const {
   if (pathIndex_.isEmpty())
-    return QString::null;
+    return QString();
 
   QVector<Qt::Key> keys;
   keys.reserve(pathIndex_.count());
@@ -2144,13 +2144,13 @@ void QGLViewer::help() {
                             tr("&About", "Help window about title")};
 
   if (!helpWidget()) {
-    // Qt4 requires a NULL parent...
-    helpWidget_ = new QTabWidget(NULL);
+    // Qt4 requires a nullptr parent...
+    helpWidget_ = new QTabWidget(nullptr);
     helpWidget()->setWindowTitle(tr("Help", "Help window title"));
 
     resize = true;
     for (int i = 0; i < 4; ++i) {
-      QTextEdit *tab = new QTextEdit(NULL);
+      QTextEdit *tab = new QTextEdit(nullptr);
       tab->setReadOnly(true);
 
       helpWidget()->insertTab(i, tab, label[i]);
@@ -2192,7 +2192,7 @@ void QGLViewer::help() {
       break;
     }
 
-    QTextEdit *textEdit = (QTextEdit *)(helpWidget()->widget(i));
+    QTextEdit *textEdit = static_cast<QTextEdit *>(helpWidget()->widget(i));
     textEdit->setHtml(text);
     textEdit->setText(text);
 
@@ -2289,7 +2289,7 @@ void QGLViewer::keyPressEvent(QKeyEvent *e) {
           camera()->deletePath(index);
         }
       } else {
-        bool nullBefore = (camera()->keyFrameInterpolator(index) == NULL);
+        bool nullBefore = (camera()->keyFrameInterpolator(index) == nullptr);
         camera()->addKeyFrameToPath(index);
         if (nullBefore)
           connect(camera()->keyFrameInterpolator(index), SIGNAL(interpolated()),
@@ -3053,7 +3053,7 @@ int QGLViewer::mouseButtonState(MouseHandler handler, MouseAction action,
        it != end; ++it)
     if ((it.value().handler == handler) && (it.value().action == action) &&
         (it.value().withConstraint == withConstraint))
-      return (int)it.key().modifiers | (int)it.key().button;
+      return static_cast<int>(it.key().modifiers) | static_cast<int>(it.key().button);
 
   return Qt::NoButton;
 }
@@ -3376,7 +3376,7 @@ void QGLViewer::setManipulatedFrame(ManipulatedFrame *frame) {
 
   manipulatedFrameIsACamera_ =
       ((manipulatedFrame() != camera()->frame()) &&
-       (dynamic_cast<ManipulatedCameraFrame *>(manipulatedFrame()) != NULL));
+       (dynamic_cast<ManipulatedCameraFrame *>(manipulatedFrame()) != nullptr));
 
   if (manipulatedFrame()) {
     // Prevent multiple connections, that would result in useless display
@@ -3431,7 +3431,7 @@ void QGLViewer::drawVisualHints() {
   // drawText(80, 10, "Play");
 
   // Screen rotate line
-  ManipulatedFrame *mf = NULL;
+  ManipulatedFrame *mf = nullptr;
   Vec pnt;
   if (camera()->frame()->action_ == SCREEN_ROTATE) {
     mf = camera()->frame();
@@ -4138,7 +4138,7 @@ void QGLViewer::copyBufferToTexture(GLint internalFormat, GLenum format) {
       format = GLenum(internalFormat);
 
     glTexImage2D(GL_TEXTURE_2D, 0, internalFormat, bufferTextureWidth_,
-                 bufferTextureHeight_, 0, format, GL_UNSIGNED_BYTE, NULL);
+                 bufferTextureHeight_, 0, format, GL_UNSIGNED_BYTE, nullptr);
   }
 
   glCopyTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, 0, 0, width(), height());

--- a/QGLViewer/qglviewer.h
+++ b/QGLViewer/qglviewer.h
@@ -257,7 +257,7 @@ public Q_SLOTS:
   /*! @name Associated objects */
   //@{
 public:
-  /*! Returns the associated qglviewer::Camera, never \c NULL. */
+  /*! Returns the associated qglviewer::Camera, never \c nullptr. */
   qglviewer::Camera *camera() const { return camera_; }
 
   /*! Returns the viewer's qglviewer::ManipulatedFrame.
@@ -269,7 +269,7 @@ public:
   See the <a href="../examples/manipulatedFrame.html">manipulatedFrame
   example</a> for a complete implementation.
 
-  Default value is \c NULL, meaning that no qglviewer::ManipulatedFrame is set.
+  Default value is \c nullptr, meaning that no qglviewer::ManipulatedFrame is set.
 */
   qglviewer::ManipulatedFrame *manipulatedFrame() const {
     return manipulatedFrame_;
@@ -283,7 +283,7 @@ public Q_SLOTS:
   /*! @name Mouse grabbers */
   //@{
 public:
-  /*! Returns the current qglviewer::MouseGrabber, or \c NULL if no
+  /*! Returns the current qglviewer::MouseGrabber, or \c nullptr if no
   qglviewer::MouseGrabber currently grabs mouse events.
 
   When qglviewer::MouseGrabber::grabsMouse(), the different mouse events are
@@ -571,7 +571,7 @@ public:
   Note that this method is not needed if you use drawText() which already calls
   it internally. */
   QFont scaledFont(const QFont &font) const {
-    if (tileRegion_ == NULL)
+    if (tileRegion_ == nullptr)
       return font;
     else {
       QFont f(font);
@@ -737,7 +737,7 @@ Q_SIGNALS:
   /*! Signal emitted by setMouseGrabber() when the mouseGrabber() is changed.
 
   \p mouseGrabber is a pointer to the new MouseGrabber. Note that this signal is
-  emitted with a \c NULL parameter each time a MouseGrabber stops grabbing
+  emitted with a \c nullptr parameter each time a MouseGrabber stops grabbing
   mouse. */
   void mouseGrabberChanged(qglviewer::MouseGrabber *mouseGrabber);
 
@@ -1210,7 +1210,7 @@ private:
   //@{
 public:
   /*! Returns a \c QList that contains pointers to all the created QGLViewers.
-    Note that this list may contain \c NULL pointers if the associated viewer
+    Note that this list may contain \c nullptr pointers if the associated viewer
   has been deleted.
 
   Can be useful to apply a method or to connect a signal to all the viewers:
@@ -1229,7 +1229,7 @@ public:
   index in unique and can be used to identify the different created QGLViewers
   (see stateFileName() for an application example).
 
-  When a QGLViewer is deleted, the QGLViewers' indexes are preserved and NULL is
+  When a QGLViewer is deleted, the QGLViewers' indexes are preserved and nullptr is
   set for that index. When a QGLViewer is created, it is placed in the first
   available position in that list. Returns -1 if the QGLViewer could not be
   found (which should not be possible). */

--- a/QGLViewer/saveSnapshot.cpp
+++ b/QGLViewer/saveSnapshot.cpp
@@ -183,13 +183,13 @@ private:
   static QProgressDialog *progressDialog;
 };
 
-QProgressDialog *ProgressDialog::progressDialog = NULL;
+QProgressDialog *ProgressDialog::progressDialog = nullptr;
 
 void ProgressDialog::showProgressDialog(QOpenGLWidget *parent) {
   progressDialog = new QProgressDialog(parent);
   progressDialog->setWindowTitle("Image rendering progress");
   progressDialog->setMinimumSize(300, 40);
-  progressDialog->setCancelButton(NULL);
+  progressDialog->setCancelButton(nullptr);
   progressDialog->show();
 }
 
@@ -206,7 +206,7 @@ void ProgressDialog::updateProgress(float progress, const QString &stepString) {
 void ProgressDialog::hideProgressDialog() {
   progressDialog->close();
   delete progressDialog;
-  progressDialog = NULL;
+  progressDialog = nullptr;
 }
 
 class VRenderInterface : public QDialog, public Ui::VRenderInterface {
@@ -221,7 +221,7 @@ public:
 // problem.
 static int saveVectorialSnapshot(const QString &fileName, QOpenGLWidget *widget,
                                  const QString &snapshotFormat) {
-  static VRenderInterface *VRinterface = NULL;
+  static VRenderInterface *VRinterface = nullptr;
 
   if (!VRinterface)
     VRinterface = new VRenderInterface(widget);
@@ -297,7 +297,7 @@ public:
 // Pops-up an image settings dialog box and save to fileName.
 // Returns false in case of problem.
 bool QGLViewer::saveImageSnapshot(const QString &fileName) {
-  static ImageInterface *imageInterface = NULL;
+  static ImageInterface *imageInterface = nullptr;
 
   if (!imageInterface)
     imageInterface = new ImageInterface(this);
@@ -466,7 +466,7 @@ bool QGLViewer::saveImageSnapshot(const QString &fileName) {
   // setCursor(QCursor(Qt::ArrowCursor));
 
   delete tileRegion_;
-  tileRegion_ = NULL;
+  tileRegion_ = nullptr;
 
   if (imageInterface->whiteBackground->isChecked())
     setBackgroundColor(previousBGColor);


### PR DESCRIPTION
Like the last one (which I close) but against your last version (2.7.1). Sorry for the  previous mistake.
It just removes some deprecated instruction and fix some warning to have a somewhat more modern code. I only modified what I stumbled into for some reasons. 