### PR TITLE
Make QGLViewer compile with Qt6

### DIFF
--- a/QGLViewer/QGLViewer.pro
+++ b/QGLViewer/QGLViewer.pro
@@ -47,6 +47,9 @@ QT *= xml opengl
 equals (QT_MAJOR_VERSION, 5) {
 	QT *= gui widgets
 }
+equals (QT_MAJOR_VERSION, 6) {
+	QT *= gui widgets openglwidgets
+}
 
 !isEmpty( QGLVIEWER_STATIC ) {
   CONFIG *= staticlib

--- a/QGLViewer/manipulatedCameraFrame.cpp
+++ b/QGLViewer/manipulatedCameraFrame.cpp
@@ -397,7 +397,11 @@ void ManipulatedCameraFrame::wheelEvent(QWheelEvent *const event,
   case QGLViewer::MOVE_BACKWARD:
     //#CONNECTION# mouseMoveEvent() MOVE_FORWARD case
     translate(
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
         inverseTransformOf(Vec(0.0, 0.0, 0.2 * flySpeed() * event->delta())));
+#else
+        inverseTransformOf(Vec(0.0, 0.0, 0.2 * flySpeed() * event->angleDelta().y())));
+#endif
     Q_EMIT manipulated();
     break;
   default:

--- a/QGLViewer/manipulatedFrame.cpp
+++ b/QGLViewer/manipulatedFrame.cpp
@@ -258,7 +258,11 @@ qreal ManipulatedFrame::deltaWithPrevPos(QMouseEvent *const event,
 
 qreal ManipulatedFrame::wheelDelta(const QWheelEvent *event) const {
   static const qreal WHEEL_SENSITIVITY_COEF = 8E-4;
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
   return event->delta() * wheelSensitivity() * WHEEL_SENSITIVITY_COEF;
+#else
+  return event->angleDelta().y() * wheelSensitivity() * WHEEL_SENSITIVITY_COEF;
+#endif
 }
 
 void ManipulatedFrame::zoom(qreal delta, const Camera *const camera) {

--- a/QGLViewer/manipulatedFrame.h
+++ b/QGLViewer/manipulatedFrame.h
@@ -7,7 +7,7 @@
 
 #include <QDateTime>
 #include <QString>
-#include <QTimer>
+#include <QElapsedTimer>
 
 namespace qglviewer {
 /*! \brief A ManipulatedFrame is a Frame that can be rotated and translated
@@ -333,7 +333,7 @@ private:
   qreal zoomSensitivity_;
 
   // Mouse speed and spinning
-  QTime last_move_time;
+  QElapsedTimer last_move_time;
   qreal mouseSpeed_;
   int delay_;
   bool isSpinning_;

--- a/QGLViewer/qglviewer.cpp
+++ b/QGLViewer/qglviewer.cpp
@@ -8,7 +8,9 @@
 #include <QDateTime>
 #include <QDir>
 #include <QFileInfo>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 #include <QGLContext>
+#endif
 #include <QImage>
 #include <QMessageBox>
 #include <QMouseEvent>
@@ -19,6 +21,11 @@
 #include <QTimer>
 #include <QUrl>
 #include <QtAlgorithms>
+#include <QPainter>
+
+#if QT_VERSION > QT_VERSION_CHECK(6, 0, 0)
+#define MidButton MiddleButton
+#endif
 
 using namespace std;
 using namespace qglviewer;
@@ -142,6 +149,9 @@ QGLViewer::QGLViewer(QWidget *parent, Qt::WindowFlags flags)
 }
 
 #ifndef DOXYGEN
+
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+
 /*! These contructors are deprecated since version 2.7.0, since they are not
  * supported by QOpenGlWidget */
 
@@ -188,6 +198,7 @@ QGLViewer::QGLViewer(const QGLFormat &format, QWidget *parent,
            "contructor instead.");
   defaultConstructor();
 }
+#endif // QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 #endif // DOXYGEN
 
 /*! Virtual destructor.
@@ -1976,7 +1987,7 @@ QString QGLViewer::cameraPathKeysString() const {
                                                   endi = pathIndex_.end();
        i != endi; ++i)
     keys.push_back(i.key());
-  qSort(keys);
+  std::sort(keys.begin(), keys.end());
 
   QVector<Qt::Key>::const_iterator it = keys.begin(), end = keys.end();
   QString res = keyString(*it);

--- a/QGLViewer/qglviewer.cpp
+++ b/QGLViewer/qglviewer.cpp
@@ -2268,7 +2268,7 @@ void QGLViewer::keyPressEvent(QKeyEvent *e) {
     unsigned int index = pathIndex_[Qt::Key(key)];
 
     // not safe, but try to double press on two viewers at the same time !
-    static QTime doublePress;
+    static QElapsedTimer doublePress;
 
     if (modifiers == playPathKeyboardModifiers()) {
       int elapsed = doublePress.restart();

--- a/QGLViewer/qglviewer.h
+++ b/QGLViewer/qglviewer.h
@@ -8,7 +8,7 @@
 #include <QGL>
 #endif
 #include <QMap>
-#include <QTime>
+#include <QElapsedTimer>
 
 class QTabWidget;
 
@@ -1297,7 +1297,7 @@ private:
   int animationTimerId_;
 
   // F P S    d i s p l a y
-  QTime fpsTime_;
+  QElapsedTimer fpsTime_;
   unsigned int fpsCounter_;
   QString fpsString_;
   qreal f_p_s_;

--- a/QGLViewer/qglviewer.h
+++ b/QGLViewer/qglviewer.h
@@ -1411,7 +1411,7 @@ private:
         return modifiers < cbp.modifiers;
       if (button != cbp.button)
         return button < cbp.button;
-      return doubleClick != cbp.doubleClick;
+      return doubleClick < cbp.doubleClick;
     }
   };
 #endif

--- a/QGLViewer/qglviewer.h
+++ b/QGLViewer/qglviewer.h
@@ -4,7 +4,9 @@
 #include "camera.h"
 
 #include <QClipboard>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 #include <QGL>
+#endif
 #include <QMap>
 #include <QTime>
 
@@ -49,6 +51,7 @@ class QGLVIEWER_EXPORT QGLViewer : public QOpenGLWidget {
 public:
   explicit QGLViewer(QWidget *parent = 0,
                      Qt::WindowFlags flags = Qt::WindowFlags());
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
   explicit QGLViewer(QWidget *parent, const QGLWidget *shareWidget,
                      Qt::WindowFlags flags = 0);
   explicit QGLViewer(QGLContext *context, QWidget *parent = 0,
@@ -57,7 +60,7 @@ public:
   explicit QGLViewer(const QGLFormat &format, QWidget *parent = 0,
                      const QGLWidget *shareWidget = 0,
                      Qt::WindowFlags flags = 0);
-
+#endif
   virtual ~QGLViewer();
 
   /*! @name Display of visual hints */
@@ -1198,8 +1201,8 @@ public Q_SLOTS:
   void setStateFileName(const QString &name) { stateFileName_ = name; }
 
 #ifndef DOXYGEN
-  void saveToFile(const QString &fileName = QString::null);
-  bool restoreFromFile(const QString &fileName = QString::null);
+  void saveToFile(const QString &fileName = QString());
+  bool restoreFromFile(const QString &fileName = QString());
 #endif
 
 private:

--- a/QGLViewer/saveSnapshot.cpp
+++ b/QGLViewer/saveSnapshot.cpp
@@ -51,7 +51,11 @@ Then calls setSnapshotFormat() with the selected one (unless the user cancels).
 Returns \c false if the user presses the Cancel button and \c true otherwise. */
 bool QGLViewer::openSnapshotFormatDialog() {
   bool ok = false;
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
   QStringList list = formats.split(";;", QString::SkipEmptyParts);
+#else
+  QStringList list = formats.split(";;", Qt::SkipEmptyParts);
+#endif
   int current = list.indexOf(FDFormatString[snapshotFormat()]);
   QString format =
       QInputDialog::getItem(this, "Snapshot format", "Select a snapshot format",
@@ -547,8 +551,7 @@ void QGLViewer::saveSnapshot(bool automatic, bool overwrite) {
   if ((automatic) && (snapshotCounter() >= 0)) {
     // In automatic mode, names have a number appended
     const QString baseName = fileInfo.baseName();
-    QString count;
-    count.sprintf("%.04d", snapshotCounter_++);
+    QString count = QString("%1").arg(snapshotCounter_++, 4, 10, QChar('0'));
     QString suffix;
     suffix = fileInfo.suffix();
     if (suffix.isEmpty())
@@ -558,7 +561,7 @@ void QGLViewer::saveSnapshot(bool automatic, bool overwrite) {
 
     if (!overwrite)
       while (fileInfo.exists()) {
-        count.sprintf("%.04d", snapshotCounter_++);
+        count = QString("%1").arg(snapshotCounter_++, 4, 10, QChar('0'));
         fileInfo.setFile(fileInfo.absolutePath() + '/' + baseName + '-' +
                          count + '.' + fileInfo.suffix());
       }

--- a/examples/constrainedFrame/constrainedFrame.cpp
+++ b/examples/constrainedFrame/constrainedFrame.cpp
@@ -3,6 +3,10 @@
 #include <QGLViewer/manipulatedCameraFrame.h>
 #include <QKeyEvent>
 
+#if QT_VERSION > QT_VERSION_CHECK(6, 0, 0)
+#define MidButton MiddleButton
+#endif
+
 using namespace qglviewer;
 using namespace std;
 

--- a/examples/examples.pri
+++ b/examples/examples.pri
@@ -1,5 +1,9 @@
 QT *= xml opengl widgets gui
 
+equals (QT_MAJOR_VERSION, 6) {
+	QT *= gui widgets openglwidgets
+}
+
 CONFIG += qt opengl warn_on thread rtti console embed_manifest_exe no_keywords
 
 # Set path to include and lib files (see doc/compilation.html for details):

--- a/examples/luxo/luxo.cpp
+++ b/examples/luxo/luxo.cpp
@@ -3,6 +3,10 @@
 
 #include <QGLViewer/manipulatedCameraFrame.h>
 
+#if QT_VERSION > QT_VERSION_CHECK(6, 0, 0)
+#define MidButton MiddleButton
+#endif
+
 using namespace qglviewer;
 using namespace std;
 

--- a/examples/manipulatedFrame/manipulatedFrame.cpp
+++ b/examples/manipulatedFrame/manipulatedFrame.cpp
@@ -3,6 +3,10 @@
 
 #include <QGLViewer/manipulatedFrame.h>
 
+#if QT_VERSION > QT_VERSION_CHECK(6, 0, 0)
+#define MidButton MiddleButton
+#endif
+
 using namespace qglviewer;
 using namespace std;
 

--- a/examples/multiSelect/object.cpp
+++ b/examples/multiSelect/object.cpp
@@ -1,5 +1,4 @@
 #include "object.h"
-#include <qgl.h>
 
 using namespace qglviewer;
 

--- a/examples/standardCamera/viewer.cpp
+++ b/examples/standardCamera/viewer.cpp
@@ -3,6 +3,10 @@
 
 #include <QKeyEvent>
 
+#if QT_VERSION > QT_VERSION_CHECK(6, 0, 0)
+#define MidButton MiddleButton
+#endif
+
 using namespace std;
 using namespace qglviewer;
 
@@ -82,7 +86,11 @@ void Viewer::wheelEvent(QWheelEvent *e) {
   if ((camera()->type() == Camera::ORTHOGRAPHIC) &&
       (((StandardCamera *)camera())->isStandard()) &&
       (e->modifiers() & Qt::ShiftModifier)) {
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     ((StandardCamera *)camera())->changeOrthoFrustumSize(e->delta());
+#else
+    ((StandardCamera *)camera())->changeOrthoFrustumSize(e->angleDelta().y());
+#endif
     Q_EMIT cameraChanged();
     update();
   } else


### PR DESCRIPTION
Here are the changes I needed to update my QGLViewer based project to Qt 6.

* There are still two examples not compiling because of reliance on \<QGL\>. (stereoViewer and standardCamera)
* The designer plugin doesn't compile (can't find "qwidgetplugin.h")

The changes are non-intrusive and should work with Qt.5.4 and above (at least).