### PR TITLE
Fix build with Qt6 on Linux/Mac

### DIFF
--- a/QGLViewer/QGLViewer.pro
+++ b/QGLViewer/QGLViewer.pro
@@ -160,6 +160,9 @@ unix {
 			equals (QT_MAJOR_VERSION, 5) {
 				TARGET = $$join(TARGET,,,-qt5)
 			}
+			equals (QT_MAJOR_VERSION, 6) {
+				TARGET = $$join(TARGET,,,-qt6)
+			}
 		}
 	}
 

--- a/examples/examples.pri
+++ b/examples/examples.pri
@@ -63,6 +63,9 @@ unix {
                 equals (QT_MAJOR_VERSION, 5) {
                     LIB_NAME = QGLViewer-qt5
                 }
+                equals (QT_MAJOR_VERSION, 6) {
+	            LIB_NAME = QGLViewer-qt6
+                }
             }
 
 			isEmpty(QMAKE_LFLAGS_RPATH) {


### PR DESCRIPTION
The examples were not compiling with Qt 6 due to the missing `TARGET` / `LIB_NAME` in the `.pro` / `.pri` files when the library is suffixed with the Qt version.