### PR TITLE
orbiting navigation added

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,9 +22,9 @@ if (Qt6_FOUND)
     message("Building with Qt6")
     set(QtLibs Qt::Core Qt::Widgets Qt::Xml Qt::OpenGL Qt::OpenGLWidgets)
 else()
-    find_package(Qt5 5.15 REQUIRED COMPONENTS Core Widgets Xml OpenGL)
+    find_package(Qt5 5 REQUIRED COMPONENTS Core Widgets Xml OpenGL)
     message("Building with Qt5")
-    set(QtLibs Qt::Core Qt::Widgets Qt::Xml Qt::OpenGL)
+    set(QtLibs Qt5::Core Qt5::Widgets Qt5::Xml Qt5::OpenGL)
 endif()
 
 

--- a/QGLViewer/qglviewer.h
+++ b/QGLViewer/qglviewer.h
@@ -1069,7 +1069,8 @@ public:
     ROLL,
     DRIVE,
     SCREEN_TRANSLATE,
-    ZOOM_ON_REGION
+    ZOOM_ON_REGION,
+    ORBIT
   };
 
 #ifndef DOXYGEN

--- a/QGLViewer/saveSnapshot.cpp
+++ b/QGLViewer/saveSnapshot.cpp
@@ -303,7 +303,12 @@ public:
 // Returns false in case of problem.
 bool QGLViewer::saveImageSnapshot(const QString &fileName) {
   static ImageInterface *imageInterface = nullptr;
+
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+  qreal devicePixelRatio = this->devicePixelRatio();
+#else
   qreal devicePixelRatio = screen()->devicePixelRatio();
+#endif
   qreal dipWidth = devicePixelRatio * width();
   qreal dipHeight = devicePixelRatio * height();
 

--- a/examples/keyboardAndMouse/keyboardAndMouse.cpp
+++ b/examples/keyboardAndMouse/keyboardAndMouse.cpp
@@ -72,6 +72,7 @@ void Viewer::init() {
                   SELECT);
   setWheelBinding(Qt::AltModifier, CAMERA, MOVE_FORWARD);
   setMouseBinding(Qt::AltModifier, Qt::LeftButton, CAMERA, TRANSLATE);
+  setMouseBinding(Qt::LeftButton, CAMERA, ORBIT);
 
   // Add custom mouse bindings description (see mousePressEvent())
   setMouseBindingDescription(Qt::NoModifier, Qt::RightButton,


### PR DESCRIPTION
the camera remains parallel to XY plane (no rolling). Tested with QT5 on Ubuntu18.04 and Ubuntu20.04. Added ORBIT into the keyboardAndMouse example.