### PR TITLE
When using QGLViewer target, propagate include/libs to compile/link with

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,8 +59,8 @@ set(QGLViewer_SRC
     "${PROJECT_SOURCE_DIR}/QGLViewer/saveSnapshot.cpp"
     "${PROJECT_SOURCE_DIR}/QGLViewer/vec.cpp")
 add_library(QGLViewer SHARED ${QGLViewer_SRC})
-target_include_directories(QGLViewer INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(QGLViewer PRIVATE ${QtLibs} OpenGL::GL OpenGL::GLU)
+target_include_directories(QGLViewer PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(QGLViewer PUBLIC ${QtLibs} OpenGL::GL OpenGL::GLU)
 
 # Example: animation.
 set(animation_SRC


### PR DESCRIPTION
PUBLIC propagates include/libs (Qt, ...) needed to use the QGLViewer target.