### PR TITLE
CMake Windows build VS2019 (vc-142)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,8 @@ if(POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)
 endif()
 
-project(libQGLViewer LANGUAGES CXX VERSION 2.9.1)
 cmake_minimum_required(VERSION 3.16)
+project(libQGLViewer LANGUAGES CXX VERSION 2.9.1)
 
 # Qt6 minimum compiler version
 set(CMAKE_CXX_STANDARD 17)
@@ -17,13 +17,14 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
 
 # This will find the Qt files.
-find_package(Qt6 COMPONENTS Core Widgets Xml OpenGL OpenGLWidgets)
-if (Qt6_FOUND)
-    message("Building with Qt6")
-    set(QtLibs Qt::Core Qt::Widgets Qt::Xml Qt::OpenGL Qt::OpenGLWidgets)
-else()
-    find_package(Qt5 5.15 REQUIRED COMPONENTS Core Widgets Xml OpenGL)
-    message("Building with Qt5")
+#find_package(Qt6 COMPONENTS Core Widgets Xml OpenGL OpenGLWidgets)
+#if (Qt6_FOUND)
+#    message("Qt6 found!")
+#    set(QtLibs Qt::Core Qt::Widgets Qt::Xml Qt::OpenGL Qt::OpenGLWidgets)
+#endif()
+find_package(Qt5 REQUIRED COMPONENTS Core Widgets Xml OpenGL)
+if(Qt5_FOUND)
+    message("Qt5 found! Preferring Qt5 for now.")
     set(QtLibs Qt::Core Qt::Widgets Qt::Xml Qt::OpenGL)
 endif()
 
@@ -100,8 +101,8 @@ set(UI_FILES
     QGLViewer/VRenderInterface.ui
     )
 
-qt5_wrap_cpp(MOC_FILES ${MOC_HEADER_FILES})
-qt5_wrap_ui(FORM_FILES ${UI_FILES})
+#qt5_wrap_cpp(MOC_FILES ${MOC_HEADER_FILES})
+#qt5_wrap_ui(FORM_FILES ${UI_FILES})
 
 add_library(QGLViewer SHARED ${HEADER_FILES} ${MOC_FILES} ${FORM_FILES} ${SOURCE_FILES})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,6 +125,7 @@ target_link_libraries(QGLViewer
 )
 
 if(WIN32)
+  # ignore minwindef.h to use std::min/max
   add_compile_definitions(NOMINMAX)
   target_compile_options(QGLViewer PRIVATE "-DCREATE_QGLVIEWER_DLL")
   # remove warnings about deprecation (CRT,etc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,40 +27,116 @@ else()
     set(QtLibs Qt::Core Qt::Widgets Qt::Xml Qt::OpenGL)
 endif()
 
-
 find_package(OpenGL REQUIRED)
 
-# QGLViewer target.
-set(QGLViewer_SRC
-    "${PROJECT_SOURCE_DIR}/QGLViewer/VRender/BackFaceCullingOptimizer.cpp"
-    "${PROJECT_SOURCE_DIR}/QGLViewer/VRender/BSPSortMethod.cpp"
-    "${PROJECT_SOURCE_DIR}/QGLViewer/VRender/EPSExporter.cpp"
-    "${PROJECT_SOURCE_DIR}/QGLViewer/VRender/Exporter.cpp"
-    "${PROJECT_SOURCE_DIR}/QGLViewer/VRender/FIGExporter.cpp"
-    "${PROJECT_SOURCE_DIR}/QGLViewer/VRender/gpc.cpp"
-    "${PROJECT_SOURCE_DIR}/QGLViewer/VRender/NVector3.cpp"
-    "${PROJECT_SOURCE_DIR}/QGLViewer/VRender/ParserGL.cpp"
-    "${PROJECT_SOURCE_DIR}/QGLViewer/VRender/Primitive.cpp"
-    "${PROJECT_SOURCE_DIR}/QGLViewer/VRender/PrimitivePositioning.cpp"
-    "${PROJECT_SOURCE_DIR}/QGLViewer/VRender/TopologicalSortMethod.cpp"
-    "${PROJECT_SOURCE_DIR}/QGLViewer/VRender/Vector2.cpp"
-    "${PROJECT_SOURCE_DIR}/QGLViewer/VRender/Vector3.cpp"
-    "${PROJECT_SOURCE_DIR}/QGLViewer/VRender/VisibilityOptimizer.cpp"
-    "${PROJECT_SOURCE_DIR}/QGLViewer/VRender/VRender.cpp"
-    "${PROJECT_SOURCE_DIR}/QGLViewer/camera.cpp"
-    "${PROJECT_SOURCE_DIR}/QGLViewer/constraint.cpp"
-    "${PROJECT_SOURCE_DIR}/QGLViewer/frame.cpp"
-    "${PROJECT_SOURCE_DIR}/QGLViewer/keyFrameInterpolator.cpp"
-    "${PROJECT_SOURCE_DIR}/QGLViewer/manipulatedCameraFrame.cpp"
-    "${PROJECT_SOURCE_DIR}/QGLViewer/manipulatedFrame.cpp"
-    "${PROJECT_SOURCE_DIR}/QGLViewer/mouseGrabber.cpp"
-    "${PROJECT_SOURCE_DIR}/QGLViewer/qglviewer.cpp"
-    "${PROJECT_SOURCE_DIR}/QGLViewer/quaternion.cpp"
-    "${PROJECT_SOURCE_DIR}/QGLViewer/saveSnapshot.cpp"
-    "${PROJECT_SOURCE_DIR}/QGLViewer/vec.cpp")
-add_library(QGLViewer SHARED ${QGLViewer_SRC})
-target_include_directories(QGLViewer INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(QGLViewer PRIVATE ${QtLibs} OpenGL::GL OpenGL::GLU)
+include_directories(
+  "${PROJECT_SOURCE_DIR}/QGLViewer/"
+  ${Qt5Core_INCLUDE_DIRS}
+  ${Qt5Widgets_INCLUDE_DIRS}
+  ${Qt5Xml_INCLUDE_DIRS}
+  ${Qt5OpenGL_INCLUDE_DIRS}
+)
+
+set(MOC_HEADER_FILES
+    QGLViewer/camera.h
+    QGLViewer/frame.h
+    QGLViewer/keyFrameInterpolator.h
+    QGLViewer/manipulatedCameraFrame.h
+    QGLViewer/manipulatedFrame.h
+    QGLViewer/qglviewer.h
+    )
+# These header files don't need to be processed by the moc.
+set(HEADER_FILES
+    QGLViewer/VRender/AxisAlignedBox.h
+    QGLViewer/VRender/Exporter.h
+    QGLViewer/VRender/NVector3.h
+    QGLViewer/VRender/Optimizer.h
+    QGLViewer/VRender/ParserGL.h
+    QGLViewer/VRender/Primitive.h
+    QGLViewer/VRender/PrimitivePositioning.h
+    QGLViewer/VRender/SortMethod.h
+    QGLViewer/VRender/Types.h
+    QGLViewer/VRender/VRender.h
+    QGLViewer/VRender/Vector2.h
+    QGLViewer/VRender/Vector3.h
+    QGLViewer/VRender/gpc.h
+    QGLViewer/config.h
+    QGLViewer/constraint.h
+    QGLViewer/domUtils.h
+    QGLViewer/mouseGrabber.h
+    QGLViewer/quaternion.h
+    QGLViewer/vec.h
+    )
+set(SOURCE_FILES
+    QGLViewer/VRender/BSPSortMethod.cpp
+    QGLViewer/VRender/BackFaceCullingOptimizer.cpp
+    QGLViewer/VRender/EPSExporter.cpp
+    QGLViewer/VRender/Exporter.cpp
+    QGLViewer/VRender/FIGExporter.cpp
+    QGLViewer/VRender/NVector3.cpp
+    QGLViewer/VRender/ParserGL.cpp
+    QGLViewer/VRender/Primitive.cpp
+    QGLViewer/VRender/PrimitivePositioning.cpp
+    QGLViewer/VRender/TopologicalSortMethod.cpp
+    QGLViewer/VRender/VRender.cpp
+    QGLViewer/VRender/Vector2.cpp
+    QGLViewer/VRender/Vector3.cpp
+    QGLViewer/VRender/VisibilityOptimizer.cpp
+    QGLViewer/VRender/gpc.cpp
+    QGLViewer/camera.cpp
+    QGLViewer/constraint.cpp
+    QGLViewer/frame.cpp
+    QGLViewer/keyFrameInterpolator.cpp
+    QGLViewer/manipulatedCameraFrame.cpp
+    QGLViewer/manipulatedFrame.cpp
+    QGLViewer/mouseGrabber.cpp
+    QGLViewer/qglviewer.cpp
+    QGLViewer/quaternion.cpp
+    QGLViewer/saveSnapshot.cpp
+    QGLViewer/vec.cpp
+    )
+set(UI_FILES
+    QGLViewer/ImageInterface.ui
+    QGLViewer/VRenderInterface.ui
+    )
+
+qt5_wrap_cpp(MOC_FILES ${MOC_HEADER_FILES})
+qt5_wrap_ui(FORM_FILES ${UI_FILES})
+
+add_library(QGLViewer SHARED ${HEADER_FILES} ${MOC_FILES} ${FORM_FILES} ${SOURCE_FILES})
+
+# WIN32 and UNIX/LINUX use different names for the OpenGL lib
+if (WIN32)
+  set(OPENGL_LIB OpenGL32)
+else()
+  set(OPENGL_LIB OpenGL)
+endif()
+
+target_link_libraries(QGLViewer 
+	                  PUBLIC 
+					  Qt5::Core 
+					  Qt5::Widgets 
+					  Qt5::OpenGL 
+					  Qt5::Xml 
+					  ${GLUT_LIBRARY}
+					  ${OPENGL_LIB}
+					  OpenGL::GLU
+)
+
+if(WIN32)
+  add_compile_definitions(NOMINMAX)
+  target_compile_options(QGLViewer PRIVATE "-DCREATE_QGLVIEWER_DLL")
+  # remove warnings about deprecation (CRT,etc)
+  target_compile_options(QGLViewer PRIVATE "/wd4996")
+endif()
+
+add_custom_command(
+  TARGET QGLViewer
+  POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -E copy
+    "$<TARGET_FILE:QGLViewer>"
+    "${CMAKE_BINARY_DIR}"
+)
 
 # Example: animation.
 set(animation_SRC

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,25 +17,22 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
 
 # This will find the Qt files.
-#find_package(Qt6 COMPONENTS Core Widgets Xml OpenGL OpenGLWidgets)
-#if (Qt6_FOUND)
-#    message("Qt6 found!")
-#    set(QtLibs Qt::Core Qt::Widgets Qt::Xml Qt::OpenGL Qt::OpenGLWidgets)
-#endif()
-find_package(Qt5 REQUIRED COMPONENTS Core Widgets Xml OpenGL)
-if(Qt5_FOUND)
-    message("Qt5 found! Preferring Qt5 for now.")
-    set(QtLibs Qt::Core Qt::Widgets Qt::Xml Qt::OpenGL)
+find_package(Qt6 COMPONENTS Core Widgets Xml OpenGL OpenGLWidgets)
+if (Qt6_FOUND)
+    message("Qt6 found!")
+    set(QtLibs Qt::Core Qt::Widgets Qt::Xml Qt::OpenGL Qt::OpenGLWidgets)
+else()
+	find_package(Qt5 REQUIRED COMPONENTS Core Widgets Xml OpenGL)
+	if(Qt5_FOUND)
+		message("Qt5 found! Preferring Qt5 for now.")
+		set(QtLibs Qt::Core Qt::Widgets Qt::Xml Qt::OpenGL)
+	endif()
 endif()
 
 find_package(OpenGL REQUIRED)
 
 include_directories(
   "${PROJECT_SOURCE_DIR}/QGLViewer/"
-  ${Qt5Core_INCLUDE_DIRS}
-  ${Qt5Widgets_INCLUDE_DIRS}
-  ${Qt5Xml_INCLUDE_DIRS}
-  ${Qt5OpenGL_INCLUDE_DIRS}
 )
 
 set(MOC_HEADER_FILES
@@ -101,9 +98,6 @@ set(UI_FILES
     QGLViewer/VRenderInterface.ui
     )
 
-#qt5_wrap_cpp(MOC_FILES ${MOC_HEADER_FILES})
-#qt5_wrap_ui(FORM_FILES ${UI_FILES})
-
 add_library(QGLViewer SHARED ${HEADER_FILES} ${MOC_FILES} ${FORM_FILES} ${SOURCE_FILES})
 
 # WIN32 and UNIX/LINUX use different names for the OpenGL lib
@@ -115,11 +109,7 @@ endif()
 
 target_link_libraries(QGLViewer 
 	                  PUBLIC 
-					  Qt5::Core 
-					  Qt5::Widgets 
-					  Qt5::OpenGL 
-					  Qt5::Xml 
-					  ${GLUT_LIBRARY}
+					  ${QtLibs} 
 					  ${OPENGL_LIB}
 					  OpenGL::GLU
 )

--- a/QGLViewer/VRender/Primitive.h
+++ b/QGLViewer/VRender/Primitive.h
@@ -21,6 +21,7 @@ namespace vrender
 {
 	class Feedback3DColor ;
 	class Primitive ;
+	std::ostream& operator<<(std::ostream&, const Feedback3DColor&);
 
 #define EPS_SMOOTH_LINE_FACTOR 0.06  /* Lower for better smooth lines. */
 

--- a/QGLViewer/VRender/Vector3.h
+++ b/QGLViewer/VRender/Vector3.h
@@ -10,6 +10,8 @@
 namespace vrender
 {
   class NVector3;
+	class Vector3;
+	std::ostream& operator<< (std::ostream&, const Vector3&);
 
 	class Vector3
 	{


### PR DESCRIPTION
This PR updates the CMakeLists.txt to allow an easy CMake configuration of the project in Windows.
The main challenge was to pass ```NOMINMAX``` to the VS projects to properly use std::min/max instead of the macros defined in minwindef.h and to ignore the VC warning 4996.

Additionally I had to add two changes suggested here:
Pull request by @bjornplitz https://github.com/GillesDebunne/libQGLViewer/pull/71
Funnily this was only necessary for building with Qt6 on Windows.

On Windows it is now only necessary to open the libQGLViewer repo folder with CMake-Gui and set either Qt5 or Qt6 dir. Qt6 also requires setting the Qt6GuiTools cmake folder.

The Linux build can now be done like this:
```
cmake -B build/ -D CMAKE_BUILD_TYPE=Release
cmake --build build/ -- -8
```
This will build everything inside the build folder.
